### PR TITLE
Design: PortfolioEdit 페이지 레이아웃을 그린다

### DIFF
--- a/src/pages/portfolioEdit/PortfolioEdit.styled.tsx
+++ b/src/pages/portfolioEdit/PortfolioEdit.styled.tsx
@@ -1,0 +1,105 @@
+import { styled } from 'styled-components';
+
+import { SquareButton } from '@/components/button/Button.styled';
+import { HEADER_HEIGHT } from '@/components/header/Header.styled';
+
+export const PortfolioEditLayout = styled.div`
+	width: 100%;
+	height: 100vh;
+
+	display: flex;
+	flex-direction: column;
+
+	background-color: salmon;;
+`;
+
+export const EditHeader = styled.header`
+	width: 100%;
+	height: ${HEADER_HEIGHT};
+
+	display: flex;
+	justify-content: space-between;
+
+	background-color: black;
+`;
+
+export const Logo = styled.div`
+	background-color: white;
+`;
+
+export const FlexContainer = styled.div`
+	width: 100%;
+	height: 100%;
+
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	background-color: blue;
+`;
+
+export const EditorSection = styled.section`
+	width: 100%;
+	height: 100%;
+
+	background-color: lemonchiffon;
+`;
+
+export const FormSection = styled.section`
+	width: 22rem;
+	height: 100%;
+
+	display: flex;
+	flex-direction: column;
+	align-items: end;
+	flex: none;
+	gap: 1rem;
+
+	padding: 3rem 1rem 2rem 1rem;
+
+	background-color: violet;
+`;
+
+export const FormBox = styled.form`
+	width: 100%;
+	height: 100%;
+
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
+
+	background-color: skyblue;
+`;
+
+export const TitleInput = styled.input`
+	height: 3.5rem;
+
+`;
+
+export const CategorySelector = styled.div`
+	width: 8rem;
+	height: 2rem;
+
+	background-color: gold;
+`;
+
+export const TagBox = styled.div`
+	width: 100%;
+
+	display: flex;
+	gap: 1rem;
+
+	background-color: yellow;
+`;
+
+export const SummaryInputArea = styled.div`
+	width: 100%;
+	height: 5rem;
+
+	background-color: red;
+`;
+
+export const SubmitButton = styled(SquareButton)`
+	width: 8rem;
+	height: 7%;
+`;

--- a/src/pages/portfolioEdit/PortfolioEdit.tsx
+++ b/src/pages/portfolioEdit/PortfolioEdit.tsx
@@ -1,9 +1,39 @@
+import { Label } from "../portfolio-detail/PortfolioDetail.styeld";
+
+import { CategorySelector, EditHeader, EditorSection, FlexContainer, FormBox, FormSection, Logo, PortfolioEditLayout, SubmitButton, SummaryInputArea, TagBox, TitleInput } from "./PortfolioEdit.styled";
+
 function PortfolioEdit(){
-    return(
-        <>
-        <h1>PortfolioEdit</h1>
-        </>
-    )
+	return(
+		<PortfolioEditLayout>
+			<EditHeader>
+				<Logo>Logo</Logo>
+			</EditHeader>
+
+			<FlexContainer>
+				<EditorSection>
+					EditorSection
+				</EditorSection>
+
+				<FormSection>
+					<FormBox>
+						<TitleInput/>
+
+						<Label>Category</Label>
+						<CategorySelector/>
+
+						<Label>Tags</Label>
+						<TagBox>
+							tagBox
+						</TagBox>
+
+						<Label>Summary</Label>
+						<SummaryInputArea/>
+					</FormBox>
+					<SubmitButton color='Black'>Submit</SubmitButton>
+				</FormSection>
+			</FlexContainer>
+		</PortfolioEditLayout>
+	)
 }
 
 export default PortfolioEdit;

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -8,7 +8,7 @@ const GlobalStyle = createGlobalStyle`
 		position: relative;
 		z-index: 0;
 
-		overflow-x: hidden;
+		/* overflow-x: hidden; */
 		box-sizing: border-box;
 	}
 


### PR DESCRIPTION
## 개요
PortfolioEdit.tsx 페이지 레이아웃 영역을 간단하게 표시합니다.

## 작업사항
* PortfolioEdit.styled.tsx 스타일드 파일을 생성한다.
* 전체적인 레이아웃 구조를 `background-color`로 표시한다.

### 변경후
![image](https://github.com/Kim-DaHam/Portfolly/assets/81691456/4f5649eb-2276-41be-b30c-fd29c6702059)