### PR TITLE
Design: Tag.tsx 컴포넌트 레이아웃을 그린다.

### DIFF
--- a/src/components/atoms/tag/Tag.styled.tsx
+++ b/src/components/atoms/tag/Tag.styled.tsx
@@ -1,0 +1,39 @@
+import { styled } from 'styled-components';
+
+export const TagContainer = styled.div<{readOnly: boolean}>`
+	width: fit-content;
+	height: 2rem;
+
+	position: relative;
+
+	display: flex;
+	align-items: center;
+
+	padding: 0 1rem 0 1rem;
+	border: 1px solid black;
+
+	cursor: ${(props)=>props.readOnly ? '' : 'pointer'};
+
+	border-radius: 1rem;
+
+	&:hover{
+		& div{
+			visibility: visible;
+		}
+		& div svg{
+			visibility: visible;
+		}
+	}
+`;
+
+export const IconBox = styled.div`
+	visibility: hidden;
+
+	& svg {
+		visibility: hidden;
+	}
+
+	position: absolute;
+	z-index: 200;
+	right: 0.5rem;
+`;

--- a/src/components/atoms/tag/Tag.tsx
+++ b/src/components/atoms/tag/Tag.tsx
@@ -1,0 +1,24 @@
+import { FiX as DeleteIcon } from "react-icons/fi";
+
+import { IconBox, TagContainer } from "./Tag.styled";
+
+type Props = {
+	readOnly: boolean;
+	value: string;
+}
+
+function Tag({readOnly, value}: Props) {
+
+	return (
+		<TagContainer readOnly={readOnly} >
+			{value}
+			{ !readOnly &&
+				<IconBox>
+					<DeleteIcon/>
+				</IconBox>
+			}
+		</TagContainer>
+	)
+}
+
+export default Tag;

--- a/src/pages/portfolioEdit/PortfolioEdit.styled.tsx
+++ b/src/pages/portfolioEdit/PortfolioEdit.styled.tsx
@@ -102,3 +102,19 @@ export const SubmitButton = styled(SquareButton)`
 	width: 8rem;
 	height: 7%;
 `;
+
+export const TagInput = styled.div`
+	min-width: 5rem;
+	max-width: fit-content;
+	height: 2rem;
+
+	display: flex;
+	align-items: center;
+
+	padding: 0 1rem 0 1rem;
+
+	border-radius: 1rem;
+
+	color: white;
+	background-color: black;
+`;

--- a/src/pages/portfolioEdit/PortfolioEdit.tsx
+++ b/src/pages/portfolioEdit/PortfolioEdit.tsx
@@ -1,8 +1,9 @@
 import { Label } from "../portfolio-detail/PortfolioDetail.styeld";
 
-import { EditHeader, EditorSection, FlexContainer, FormBox, FormSection, Logo, PortfolioEditLayout, SubmitButton, SummaryInputArea, TagBox, TitleInput } from "./PortfolioEdit.styled";
+import { EditHeader, EditorSection, FlexContainer, FormBox, FormSection, Logo, PortfolioEditLayout, SubmitButton, SummaryInputArea, TagBox, TagInput, TitleInput } from "./PortfolioEdit.styled";
 
 import Selector from "@/components/atoms/selector/Selector";
+import Tag from "@/components/atoms/tag/Tag";
 
 function PortfolioEdit(){
 	return(
@@ -28,7 +29,8 @@ function PortfolioEdit(){
 
 						<Label>Tags</Label>
 						<TagBox>
-							tagBox
+							<TagInput contentEditable/>
+							<Tag readOnly={false} value={'Tag'}/>
 						</TagBox>
 
 						<Label>Summary</Label>


### PR DESCRIPTION
## 개요
Tag.tsx 컴포넌트를 생성했습니다.
아직 기능은 없고 컴포넌트 레이아웃만 존재합니다.

## 작업사항
* Tag.tsx 컴포넌트 레이아웃을 그린다.
  * 쓰기 전용/읽기 전용 태그를 구분한다.
  * 쓰기 전용 태그는 마우스 hover 시 X 버튼이 나타난다. -> PortfolioEdit.tsx에서 사용
  * 읽기 전용 태그는 X 버튼이 나타나지 않고 마우스 모양이 cursor가 아니다. -> PortfolioDetail.tsx
* TagInput 스타일드 컴포넌트를 만든다.
  *  PortfolioEdit.tsx에서 사용자 태그를 입력하는 입력란이다.
  * 입력되는 글자 수만큼 길이가 늘어나고 줄어든다.

### 변경후

https://github.com/Kim-DaHam/Portfolly/assets/81691456/47ac561d-cb11-439a-9140-a870d44e5023

