### PR TITLE
Feat: MessagePage.tsx 전문가의 의뢰폼 작성 기능을 구현한다

### DIFF
--- a/src/components/atoms/selector/Selector.constants.ts
+++ b/src/components/atoms/selector/Selector.constants.ts
@@ -1,5 +1,5 @@
 import { categories, commissionStates, messageStates, searchFilters, sections } from "@/assets/data/fields";
-import { CommissionState, MessageState, SearchFilter, Section } from '@/types';
+import { CommissionStatus, MessageStatus, SearchFilter, Section } from '@/types';
 
 type SelectorList = {
 	section: Section[];
@@ -7,16 +7,16 @@ type SelectorList = {
 		[key in Section] : string[];
 	};
 	commissionType: Array<Section | '전체 상품'>;
-	commissionState: Array<CommissionState | '전체 상태'>;
+	commissionStatus: Array<CommissionStatus | '전체 상태'>;
 	searchFilter: SearchFilter[];
-	messageState: Array<MessageState | '전체'>;
+	messageStatus: Array<MessageStatus | '전체'>;
 };
 
 export const selectorList: SelectorList = {
 	section: [...sections],
 	category: {...categories},
 	commissionType: ['전체 상품', ...sections],
-	commissionState: ['전체 상태', ...commissionStates],
+	commissionStatus: ['전체 상태', ...commissionStates],
 	searchFilter: [...searchFilters],
-	messageState: ['전체', ...messageStates],
+	messageStatus: ['전체', ...messageStates],
 };

--- a/src/components/atoms/selector/Selector.tsx
+++ b/src/components/atoms/selector/Selector.tsx
@@ -10,7 +10,7 @@ import useSelector from "@/hooks/component/useSelector";
 import { SetState } from "@/types";
 import { Section } from "@/types/portfolio";
 
-export type TSelector = 'section' | 'category' | 'commissionType' | 'commissionState' | 'searchFilter' | 'messageState';
+export type TSelector = 'section' | 'category' | 'commissionType' | 'commissionStatus' | 'searchFilter' | 'messageStatus';
 
 type Props = HTMLAttributes<HTMLDivElement> & {
 	type: TSelector;

--- a/src/components/molecules/items/commission-item/CommissionItem.tsx
+++ b/src/components/molecules/items/commission-item/CommissionItem.tsx
@@ -33,7 +33,7 @@ export default function CommissionItem({ commission, index }: Props) {
 					<Text type='small'>{commission.client.nickname}</Text>
 					<Text type='small'>{toLocalDateString(new Date(commission.createdAt))}</Text>
 				</S.Box>
-				{ auth === 'expert' &&
+				{ auth === 'expert' && commission.review &&
 					<Button color='gray' onClick={handleReviewButton}>
 						{isReviewOpen ? '리뷰 닫기' : '리뷰 확인'}
 					</Button>

--- a/src/components/organisms/message-room-list/MessageRoomList.tsx
+++ b/src/components/organisms/message-room-list/MessageRoomList.tsx
@@ -36,7 +36,7 @@ export default function MessageRoomList({ messageRooms }: Props) {
 	return (
 		<S.Wrapper>
 			<S.SearchBox>
-				<Selector type='messageState' placeholder='전체' setSelectorValue={setMessageFilter} size='7rem' />
+				<Selector type='messageStatus' placeholder='전체' setSelectorValue={setMessageFilter} size='7rem' />
 			</S.SearchBox>
 
 			<S.MessageRoomBox>

--- a/src/components/organisms/modal/commission-modal/CommissionModal.tsx
+++ b/src/components/organisms/modal/commission-modal/CommissionModal.tsx
@@ -104,6 +104,7 @@ export default function RequestModal({ commission, handleModal, editMode }: Prop
 							<Text type='titleSmall'>{updatedCommission.details.title}</Text>
 						}
 						<Text type='small'>{updatedCommission.createdAt}</Text>
+						{updatedCommission.details && <Text type='small'>{updatedCommission.details.status}</Text>}
 					</S.Box>
 
 					<S.Box>

--- a/src/components/organisms/modal/commission-modal/CommissionModal.tsx
+++ b/src/components/organisms/modal/commission-modal/CommissionModal.tsx
@@ -9,13 +9,13 @@ import * as S from "./CommissionModal.styled";
 import { Text, Button, Modal, Profile, Rating } from "@/components";
 import { useStopScrollY } from "@/hooks";
 import { authority } from "@/redux/loginSlice";
-import { setToast } from "@/redux/toastSlice";
 import { addValidationErrorToast } from "@/utils";
 import { usePostCommissionQuery } from "@/utils/api-service/commission";
 
 type Props = {
 	commission: any;
 	handleModal: MouseEventHandler<HTMLElement>;
+	editMode?: boolean;
 };
 
 export type FormValues = {
@@ -32,9 +32,9 @@ const defaultValues: FormValues = {
 	cost: 0,
 };
 
-export default function RequestModal({ commission, handleModal }: Props) {
+export default function RequestModal({ commission, handleModal, editMode }: Props) {
 	const [updatedCommission, setUpdatedCommission] = useState(commission);
-	const [isEditMode, setIsEditMode] = useState(false);
+	const [isEditMode, setIsEditMode] = useState(editMode);
 
 	const dispatch = useDispatch();
 
@@ -45,7 +45,7 @@ export default function RequestModal({ commission, handleModal }: Props) {
 		defaultValues: defaultValues,
 	});
 
-	const commissionMutation = usePostCommissionQuery(commission.id);
+	const commissionMutation = usePostCommissionQuery(commission.id, commission.clientId);
 
 	useStopScrollY();
 
@@ -57,10 +57,10 @@ export default function RequestModal({ commission, handleModal }: Props) {
 		changedKeys.map((key) => {
 			changedValues[key] = copyForm[key];
 		});
-		changedValues.section = form.section;
 
 		await commissionMutation.mutate(changedValues, {
 			onSuccess: (response) => {
+				console.log('onSuccess')
 				setIsEditMode(prev=>!prev);
 				setUpdatedCommission(response);
 			},
@@ -68,12 +68,16 @@ export default function RequestModal({ commission, handleModal }: Props) {
 	};
 
 	useEffect(() => {
-		reset({
-			title: commission.details.title,
-			content: commission.details.content,
-			deadline: commission.details.deadline,
-			cost: commission.details.cost,
-		});
+		if(commission.details) {
+			reset({
+				title: commission.details.title,
+				content: commission.details.content,
+				deadline: commission.details.deadline,
+				cost: commission.details.cost,
+			});
+			return;
+		}
+		setUpdatedCommission({...commission, details: {...defaultValues}});
 	}, []);
 
 	useEffect(() => {

--- a/src/components/organisms/partner-profile/PartnerProfile.tsx
+++ b/src/components/organisms/partner-profile/PartnerProfile.tsx
@@ -1,16 +1,31 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useSelector } from "react-redux";
 
-import { Text, Button, Profile } from "@/components";
+import { Text, Button, Profile, CommissionModal } from "@/components";
 import * as S from "@/components/organisms/partner-profile/PartnerProfile.styled";
+import { useModal } from "@/hooks";
 import { authority } from "@/redux/loginSlice";
+import { toLocalDateString } from "@/utils";
 
 type Props = {
 	message: any;
 };
 
 export default function PartnerProfile({ message }: Props) {
+	const queryClient = useQueryClient();
 
 	const auth = useSelector(authority);
+	const { isModalOpen, handleModal} = useModal();
+	const messageQuery = queryClient.getQueryData(['message', `${message.clientId}`]) as any;
+
+	const initialCommission = {
+		id: undefined,
+		portfolioId: message.portfolioId,
+		clientId: message.clientId,
+		portfolio: message.portfolio,
+		createdAt: toLocalDateString(new Date(Date.now())),
+		expert: message.portfolio.expert,
+	};
 
 	return(
 		<S.Wrapper>
@@ -30,12 +45,19 @@ export default function PartnerProfile({ message }: Props) {
 			<Text type='label'>전문가 서비스</Text>
 			<Profile type='portfolio' user={message.portfolio} />
 
-			{ message.commissionStatus === null && auth === 'expert' &&
-				<Button color='black' size='full'>의뢰 폼 전송</Button>
+			{ !message.commission && auth === 'expert' &&
+				<Button color='black' size='full' onClick={handleModal}>의뢰 폼 전송</Button>
 			}
 
-			{ message.commissionStatus !== null &&
-				<Button color='gray' size='full'>의뢰 폼 확인</Button>
+			{ message.commission &&
+				<Button color='gray' size='full' onClick={handleModal}>의뢰 폼 확인</Button>
+			}
+
+			{ isModalOpen && !message.commission && auth === 'expert' &&
+				<CommissionModal commission={initialCommission} handleModal={handleModal} editMode />
+			}
+			{ isModalOpen && message.commission &&
+				<CommissionModal commission={messageQuery.commission} handleModal={handleModal} />
 			}
 		</S.Wrapper>
 	)

--- a/src/components/organisms/profile-description/management/Management.tsx
+++ b/src/components/organisms/profile-description/management/Management.tsx
@@ -14,7 +14,7 @@ type Props = {
 
 export type FormValues = {
 	commissionType: string;
-	commissionState: string;
+	commissionStatus: string;
 	searchFilter: '닉네임' | '프로젝트명';
 	searchKeyword: string;
 	startDate: string | null;
@@ -23,7 +23,7 @@ export type FormValues = {
 
 const defaultValues: FormValues = {
 	commissionType: '전체 상품',
-	commissionState: '전체 상태',
+	commissionStatus: '전체 상태',
 	searchFilter: '닉네임',
 	searchKeyword: '',
 	startDate: null,
@@ -42,7 +42,7 @@ export default function Management({ commissions }: Props) {
 		const filteredCommissions = commissions.filter((commission: any) => {
 			return (
 				(data.commissionType === '전체 상품' || commission.portfolio.section === data.commissionType) &&
-				(data.commissionState === '전체 상태' || commission.details.state === data.commissionState) &&
+				(data.commissionStatus === '전체 상태' || commission.details.state === data.commissionStatus) &&
 				(data.startDate === null || new Date(commission.createdAt) <= new Date(data.endDate!)) &&
 				(data.endDate === null || new Date(commission.endedAt) >= new Date(data.startDate!)) &&
 				(data.searchKeyword === '' || isIncludedKeyword(data.searchFilter, commission, data.searchKeyword))
@@ -69,10 +69,10 @@ export default function Management({ commissions }: Props) {
 						{...register('commissionType')}
 					/>
 					<Selector
-						type='commissionState'
+						type='commissionStatus'
 						placeholder='전체 상태'
 						setValue={setValue}
-						{...register('commissionState')}
+						{...register('commissionStatus')}
 					/>
 
 					<S.DateSelector>

--- a/src/components/organisms/tracking/Tracking.helpers.ts
+++ b/src/components/organisms/tracking/Tracking.helpers.ts
@@ -1,7 +1,8 @@
-import { CommissionState } from "@/types";
+import { CommissionStatus } from "@/types";
 
-export const countCommissionState = (commissions: any[]) => {
-	const commissionsState: {[key in CommissionState | string]: number} = {
+export const countCommissionStatus = (commissions: any[]) => {
+	console.log(commissions)
+	const commissionsStatus: {[key in CommissionStatus | string]: number} = {
 		'진행 중': 0,
 		'작업물 도착': 0,
 		'취소/문제해결': 0,
@@ -12,17 +13,17 @@ export const countCommissionState = (commissions: any[]) => {
 	};
 
 	commissions.map((commission: any) => {
-		const state = commission.details.state as CommissionState;
-		commissionsState[state] += 1;
+		const status = commission.details.status as CommissionStatus;
+		commissionsStatus[status] += 1;
 
-		if(state === '구매 확정' && commission.review === null) {
-			commissionsState['작성 가능한 리뷰'] += 1;
+		if(status === '구매 확정' && commission.review === null) {
+			commissionsStatus['작성 가능한 리뷰'] += 1;
 		}
 
 		if(commission.review) {
-			commissionsState['작성된 리뷰'] += 1;
+			commissionsStatus['작성된 리뷰'] += 1;
 		}
 	});
 
-	return commissionsState;
+	return commissionsStatus;
 };

--- a/src/components/organisms/tracking/Tracking.tsx
+++ b/src/components/organisms/tracking/Tracking.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { countCommissionState } from './Tracking.helpers';
+import { countCommissionStatus } from './Tracking.helpers';
 
 import { ProcessIcon, FolderIcon, CancelIcon } from '@/assets/images';
 import { Image, Text } from "@/components";
@@ -12,7 +12,7 @@ type Props = {
 };
 
 export default function Tracking({ commissions }: Props) {
-	const commissionsState = countCommissionState(commissions);
+	const commissionsStatus = countCommissionStatus(commissions);
 
 	const auth = useSelector(authority);
 
@@ -24,7 +24,7 @@ export default function Tracking({ commissions }: Props) {
 						<Image src={ProcessIcon} size='2rem' />
 						<Text type='common'>진행 중</Text>
 					</S.LabelGroup>
-					<Text type='titleSmall'>{commissionsState['진행 중']}</Text>
+					<Text type='titleSmall'>{commissionsStatus['진행 중']}</Text>
 				</S.Box>
 
 				<S.Box>
@@ -32,7 +32,7 @@ export default function Tracking({ commissions }: Props) {
 						<Image src={FolderIcon} size='2rem' />
 						<Text type='common'>작업물 도착</Text>
 					</S.LabelGroup>
-					<Text type='titleSmall'>{commissionsState['작업물 도착']}</Text>
+					<Text type='titleSmall'>{commissionsStatus['작업물 도착']}</Text>
 				</S.Box>
 
 				<S.Box>
@@ -40,30 +40,30 @@ export default function Tracking({ commissions }: Props) {
 						<Image src={CancelIcon} size='2rem' />
 						<Text type='common'>취소 · 문제해결</Text>
 					</S.LabelGroup>
-					<Text type='titleSmall'>{commissionsState['취소/문제해결']}</Text>
+					<Text type='titleSmall'>{commissionsStatus['취소/문제해결']}</Text>
 				</S.Box>
 
 				<S.Box>
 					<S.Group>
 						<Text type='common'>구매 확정</Text>
-						<Text type='common'>{commissionsState['구매 확정']}</Text>
+						<Text type='common'>{commissionsStatus['구매 확정']}</Text>
 					</S.Group>
 
 					{ auth === 'expert' ?
 						<S.Group>
 							<Text type='common'>작성된 리뷰</Text>
-							<Text type='common'>{commissionsState['작성된 리뷰']}</Text>
+							<Text type='common'>{commissionsStatus['작성된 리뷰']}</Text>
 						</S.Group>
 						:
 						<S.Group>
 							<Text type='common'>작성 가능한 리뷰</Text>
-							<Text type='common'>{commissionsState['작성 가능한 리뷰']}</Text>
+							<Text type='common'>{commissionsStatus['작성 가능한 리뷰']}</Text>
 						</S.Group>
 					}
 
 					<S.Group>
 						<Text type='common'>주문 취소</Text>
-						<Text type='common'>{commissionsState['주문 취소']}</Text>
+						<Text type='common'>{commissionsStatus['주문 취소']}</Text>
 					</S.Group>
 				</S.Box>
 			</S.Content>

--- a/src/hooks/component/useCategorySlider.ts
+++ b/src/hooks/component/useCategorySlider.ts
@@ -23,7 +23,11 @@ export default function useCategorySlider() {
 	const lastIndex = categories[currentSection].length - 1;
 
 	const handlePrev = () => {
-		setShowNextArrow(true);
+		const lastCategoryButton = document.querySelector('.last-category') as HTMLElement;
+		const endOfSlider = lastCategoryButton.getBoundingClientRect().right;
+
+		if(!(endOfSlider - SLIDE_WIDTH * 2 <= endOfCategoryBox))
+			setShowNextArrow(true);
 
 		if(sliderLeft + SLIDE_WIDTH * 2 > 0){
 			setShowPrevArrow(false);
@@ -31,7 +35,9 @@ export default function useCategorySlider() {
 			setSliderLeft(0);
 			return;
 		}
-		if(slider) slider.style.left = `${sliderLeft + SLIDE_WIDTH}px`;
+		if(slider)
+			slider.style.left = `${sliderLeft + SLIDE_WIDTH}px`;
+
 		setSliderLeft(prev => prev + SLIDE_WIDTH);
 	};
 

--- a/src/mocks/data/commissions.ts
+++ b/src/mocks/data/commissions.ts
@@ -8,7 +8,7 @@ export const commissions = [
 		endedAt: '2024-05-06',
 		details: {
 			title: '앱 포트폴리오 커미션',
-			state: '구매 확정',
+			status: '구매 확정',
 			content: '앱 포트폴리오 커미션 설명',
 			cost: 350000,
 			deadline: '2024-05-06',
@@ -24,7 +24,7 @@ export const commissions = [
 		endedAt: '2024-05-06',
 		details: {
 			title: '웹 포트폴리오 커미션1',
-			state: '진행 중',
+			status: '진행 중',
 			content: '웹 포트폴리오 커미션 설명',
 			cost: 350000,
 			deadline: '2024-05-06',
@@ -44,7 +44,7 @@ export const commissions = [
 		endedAt: '2024-05-06',
 		details: {
 			title: '웹 포트폴리오 커미션2',
-			state: '진행 중',
+			status: '진행 중',
 			content: '웹 포트폴리오 커미션 설명',
 			cost: 350000,
 			deadline: '2024-05-06',
@@ -64,7 +64,7 @@ export const commissions = [
 		endedAt: '2024-05-06',
 		details: {
 			title: '일러스트 포트폴리오 커미션',
-			state: '진행 중',
+			status: '진행 중',
 			content: '일러스트 포트폴리오 커미션 설명',
 			cost: 350000,
 			deadline: Date.now(),
@@ -72,6 +72,46 @@ export const commissions = [
 		review: {
 			createdAt: Date.now(),
 			content: '일러스트 리뷰입니다~',
+			score: 50,
+		},
+	},
+	{
+		id: 5,
+		portfolioId: 2,
+		expertId: 2,
+		clientId: 100,
+		createdAt: '2024-03-06',
+		endedAt: '2024-05-06',
+		details: {
+			title: '앱 포트폴리오 커미션',
+			status: '진행 중',
+			content: '앱 포트폴리오 커미션 설명',
+			cost: 350000,
+			deadline: Date.now(),
+		},
+		review: {
+			createdAt: Date.now(),
+			content: '앱 리뷰입니다~',
+			score: 50,
+		},
+	},
+	{
+		id: 6,
+		portfolioId: 3,
+		expertId: 3,
+		clientId: 100,
+		createdAt: '2024-03-06',
+		endedAt: '2024-05-06',
+		details: {
+			title: '앱 포트폴리오 커미션',
+			status: '구매 확정',
+			content: '앱 포트폴리오 커미션 설명',
+			cost: 350000,
+			deadline: Date.now(),
+		},
+		review: {
+			createdAt: Date.now(),
+			content: '앱 리뷰입니다~',
 			score: 50,
 		},
 	},

--- a/src/mocks/data/messages.ts
+++ b/src/mocks/data/messages.ts
@@ -7,7 +7,7 @@ export const messageRooms = [
 		expertId: 1,
 		clientId: 100,
 		portfolioId: 1,
-		commissionStatus: null,
+		commissionId: null,
 		lastMessage: '마지막 메세지입니다dddddddd',
 		timestamp: Date.now(),
 		messages: [
@@ -186,7 +186,7 @@ export const messageRooms = [
 		expertId: 2,
 		clientId: 100,
 		portfolioId: 2,
-		commissionStatus: '진행 중',
+		commissionId: 5,
 		lastMessage: '마지막 메세지입니다',
 		timestamp: Date.now(),
 		messages: [
@@ -212,7 +212,7 @@ export const messageRooms = [
 		expertId: 3,
 		clientId: 100,
 		portfolioId: 3,
-		commissionStatus: '구매 확정',
+		commissionId: 6,
 		lastMessage: '마지막 메세지입니다',
 		timestamp: Date.now(),
 		messages: [

--- a/src/mocks/handlers/commission.ts
+++ b/src/mocks/handlers/commission.ts
@@ -39,7 +39,7 @@ export const commissionHandlers= [
 			endedAt: '',
 			details: {
 				cost: 0,
-				state: '진행 중',
+				status: '진행 중',
 				...commission,
 			},
 			review: null,

--- a/src/mocks/handlers/commission.ts
+++ b/src/mocks/handlers/commission.ts
@@ -1,67 +1,89 @@
 import { HttpResponse, http } from 'msw';
 
 import { commissions } from '../data/commissions';
+import { portfolios } from '../data/portfolios';
+import { users } from '../data/users';
+
+const LOGIN_ID = 1;
 
 export const commissionHandlers= [
-	// http.post(`/commissions`, async ({request}) => {
-	// 	const newPortfolio = await request.json() as FormValues;
-	// 	const portfolioId = portfolios.length + 1;
-	// 	const sectionId = sectionIdMap.get(newPortfolio.section) as number;
-	// 	const categoryId = getCategoryId(newPortfolio.category) as number;
-	// 	const tagId = getTagId(newPortfolio.tags, sectionId, portfolioId) as number[];
+	http.post(`/commissions`, async ({request}) => {
+		const url = new URL(request.url);
+		const portfolioId = url.searchParams.get('portfolio_id') as string;
+		const clientId = url.searchParams.get('client_id') as string;
 
-	// 	portfolios.push({
-	// 		id: portfolioId,
-	// 		userId: 1,
-	// 		title: newPortfolio.title,
-	// 		content: newPortfolio.content,
-	// 		summary: newPortfolio.summary,
-	// 		createdAt: Date.now(),
-	// 		modifiedAt: Date.now(),
-	// 		sectionId: sectionId,
-	// 		categoryId: categoryId,
-	// 		tagId: tagId,
-	// 		likes: 0,
-	// 		images: [],
-	// 	});
+		const commission = await request.json() as any;
+		const commissionId = commissions.length + 1;
+		const expert = users.find((user) => user.id === LOGIN_ID);
+		const portfolio = portfolios.find((portfolio) => portfolio.id === Number(portfolioId));
 
-	// 	return HttpResponse.json({id: portfolioId}, { status: 200 });
-	// }),
+		const newCommission = {
+			id: commissionId,
+			portfolioId: Number(portfolioId),
+			portfolio: {
+				id: Number(portfolioId),
+				title: portfolio?.title,
+				summary: portfolio?.summary,
+				thumbnailUrl: portfolio?.images[0],
+			},
+			expertId: LOGIN_ID,
+			expert: {
+				id: LOGIN_ID,
+				nickname: expert?.nickname,
+				name: expert?.name,
+				phone: expert?.phone,
+				profileImage: expert?.profileImage,
+			},
+			clientId: Number(clientId),
+			createdAt: `${Date.now()}`,
+			endedAt: '',
+			details: {
+				cost: 0,
+				state: '진행 중',
+				...commission,
+			},
+			review: null,
+		};
+
+		commissions.push(newCommission);
+
+		return HttpResponse.json(newCommission, { status: 200 });
+	}),
 
 	http.patch(`/commissions`, async ({request}) => {
 		const url = new URL(request.url);
 		const commissionId = url.searchParams.get('id') as string;
 		const commissionData = await request.json() as any;
-		const responseData: any = {};
+		const response: any = {};
 
 		commissions.map((commission: any) => {
 			if(commission.id === Number(commissionId)){
 				Object.assign(commission.details, commissionData);
-				Object.assign(responseData, commission);
+				Object.assign(response, commission);
 			}
 		});
 
-		return HttpResponse.json(responseData, { status: 200 });
+		return HttpResponse.json(response, { status: 200 });
 	}),
 
 	http.post(`/reviews`, async ({request}) => {
 		const url = new URL(request.url);
 		const commissionId = url.searchParams.get('id') as string;
 		const reviewData = await request.json() as any;
-		const responseData: any = {};
+		const response: any = {};
 
 		const commission = commissions.find((commission: any) => {
 			return commission.id === Number(commissionId);
 		});
 
-		Object.assign(responseData, {
+		Object.assign(response, {
 			createdAt: Date.now(),
 			...reviewData,
 		});
 
-		commission!.review = responseData;
+		commission!.review = response;
 
-		return HttpResponse.json(responseData, { status: 200 });
+		return HttpResponse.json(response, { status: 200 });
 	})
 
 ];

--- a/src/mocks/handlers/message.ts
+++ b/src/mocks/handlers/message.ts
@@ -1,13 +1,14 @@
 import { HttpResponse, http } from 'msw';
 
+import { commissions } from '../data/commissions';
 import { messageRooms } from '../data/messages';
 import { portfolios } from '../data/portfolios';
 import { users } from '../data/users';
 
 import { User } from '@/types';
 
-const LOGIN_ID: number = 100;
-const AUTHORITY: string = 'client';
+const LOGIN_ID: number = 1;
+const AUTHORITY: string = 'expert';
 const PARTNER_ID = (AUTHORITY === 'expert') ? 'clientId' : 'expertId';
 const MY_ID = AUTHORITY + 'Id';
 
@@ -39,10 +40,13 @@ export const messageHandlers= [
 					}
 				});
 
+				// '/messages' 경로로 들어와 partnerId가 존재하지 않을 경우 가장 첫 번째 messageRoom 정보를 받는다.
 				if(Object.keys(message).length === 0 || Number(partnerId) === partner?.id) {
 					const recentMessages = room.messages.filter((_: any ,index: number) => index < 50);
 
+					const commission = commissions.find((commission) => commission.id === room.commissionId);
 					const portfolio = portfolios.find((portfolio) => portfolio.id === room.portfolioId);
+					const expert = users.find((user) => user.id === portfolio?.userId);
 
 					Object.assign(message, {
 						...room,
@@ -56,7 +60,15 @@ export const messageHandlers= [
 							title: portfolio?.title,
 							summary: portfolio?.summary,
 							thumbnailUrl: portfolio?.images[0],
+							expert: {
+								id: expert?.id,
+								nickname: expert?.nickname,
+								name: expert?.name,
+								phone: expert?.phone,
+								profileImage: expert?.profileImage,
+							}
 						},
+						commission: commission || null,
 						messages: recentMessages,
 					});
 				}

--- a/src/mocks/handlers/user.ts
+++ b/src/mocks/handlers/user.ts
@@ -6,12 +6,13 @@ import { users } from '../data/users';
 
 import { getSection } from '@/utils';
 
+const LOGIN_ID = 1;
+
 export const userHandlers= [
 	http.get('/users', ({request}) => {
 		const url = new URL(request.url);
 		const userId = url.searchParams.get('id') as string;
-		const loginId = '100';
-		const isMyProfile = userId === loginId;
+		const isMyProfile = userId === String(LOGIN_ID);
 
 		const user = users.find((user) => {
 			return user.id === Number(userId);
@@ -40,7 +41,7 @@ export const userHandlers= [
 
 		const bookmarkList: any[] = [];
 
-		if(userId === loginId) {
+		if(userId === String(LOGIN_ID)) {
 			portfolios.map((portfolio) => {
 				const isBookmarked = user!.bookmarks!.indexOf(portfolio.id) > -1;
 

--- a/src/redux/loginSlice.ts
+++ b/src/redux/loginSlice.ts
@@ -9,9 +9,9 @@ type InitialState = {
 }
 
 const initialState: InitialState = {
-	authority: 'client',
+	authority: 'expert',
 	isLogin: true,
-	userId: 100,
+	userId: 1,
 };
 
 export const loginSlice = createSlice({

--- a/src/types/commission.ts
+++ b/src/types/commission.ts
@@ -1,3 +1,3 @@
-export type CommissionState = '진행 중' | '작업물 도착' | '구매 확정' | '주문 취소' | '취소/문제해결' | '분쟁 조정 중';
+export type CommissionStatus = '진행 중' | '작업물 도착' | '구매 확정' | '주문 취소' | '취소/문제해결' | '분쟁 조정 중';
 export type SearchFilter = '닉네임' | '프로젝트명';
-export type MessageState = '안 읽음' | '거래 중';
+export type MessageStatus = '안 읽음' | '거래 중';

--- a/src/utils/api-service/commission.ts
+++ b/src/utils/api-service/commission.ts
@@ -4,35 +4,37 @@ import { useSelector } from "react-redux";
 import { userId as UserId} from "@/redux/loginSlice";
 import { fetch } from '@/utils'
 
-export const usePostCommissionQuery = (id?: number) => {
+export const usePostCommissionQuery = (commissionId?: number, clientId?: number) => {
 	const queryClient = useQueryClient();
+
 	const userId = String(useSelector(UserId));
 	const user = queryClient.getQueryData(['user', userId]) as any;
+	const message = queryClient.getQueryData(['message', `${clientId}`]) as any;
 
-	const postPortfolio = (body: any) => fetch(`/commissions`, 'POST', body);
-	const updatePortfolio = (body: any) => fetch(`/commissions?id=${id}`, 'PATCH', body);
+	const addCommission = (body: any) => fetch(`/commissions?portfolio_id=${message.portfolioId}&client_id=${message.clientId}`, 'POST', body);
+	const updateCommission = (body: any) => fetch(`/commissions?id=${commissionId}`, 'PATCH', body);
 
 	return useMutation({
-		mutationFn: id? updatePortfolio : postPortfolio,
+		mutationFn: commissionId? updateCommission : addCommission,
 		onSuccess: (response: any) => {
-			const responseData = {};
 
-			if(id) {
+			if(commissionId && user) {
 				queryClient.setQueryData(['user', userId], () => {
 					const commission = user.activity.commissions.find((commission: any) => {
-						return commission.id === id;
+						return commission.id === commissionId;
 					})
-
 					Object.assign(commission, response);
-					Object.assign(responseData, commission);
 				});
 
-				return responseData;
+				return response;
 			}
 
-			queryClient.setQueryData(['user', userId], () => {
-				user.activity.commissions.push(response);
+			queryClient.setQueryData(['message', `${clientId}`], () => {
+				commissionId = response.id;
+				message.commission = response;
 			});
+
+			return response;
 		},
 	});
 };


### PR DESCRIPTION
## 개요
MessagePage.tsx 페이지에서 전문가의 의뢰폼 작성 기능을 구현한다

## 작업사항
* 의뢰가 시작되지 않은 채팅방의 경우, 전문가 화면에 '의뢰 폼 작성' 버튼이 나타난다.
  * 버튼 클릭 시 의뢰 폼을 작성할 수 있다.
  * 의뢰 폼 작성 시 '의뢰 폼 확인' 버튼으로 바뀐다.
  * 의뢰는 언제든지 수정 가능하다.
  * 의뢰가 등록되면 클라이언트 채팅방 화면에도 '의뢰 폼 확인' 버튼이 나타난다.

### 변경후

https://github.com/Kim-DaHam/Portfolly/assets/81691456/322721b6-5d82-4a99-822b-bb87250d202b

