### PR TITLE
Feat: 체험 로그인/로그아웃 기능을 구현한다

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ import { PersistGate } from 'redux-persist/integration/react';
 
 
 
+import MainLayout from './pages/main-layout/MainLayout';
+
 import { Footer, Header, ToastContainer } from '@/components';
 import IntroPage from '@/pages/intro/IntroPage';
 import LogInPage from '@/pages/log-in/LogInPage';
@@ -32,18 +34,18 @@ export default function App() {
 				<PersistGate loading={null} persistor={persistor}>
 					<QueryClientProvider client={queryClient}>
 						<BrowserRouter>
-							<Header />
 							<Routes>
+							<Route element={<MainLayout />}>
 								<Route path={ROUTE_PATH.INTRO} element={<IntroPage/>} />
 								<Route path={ROUTE_PATH.MAIN} element={<MainPage/>} />
-								<Route path={ROUTE_PATH.LOGIN} element={<LogInPage/>} />
 								<Route path={ROUTE_PATH.MY_PAGE} element={<MyPage/>} />
 								<Route path={ROUTE_PATH.MY_PAGE_TAB} element={<MyPage/>} />
 								<Route path={ROUTE_PATH.PORTFOLIO_DETAIL} element={<PortfolioDetailPage/>} />
 								<Route path={ROUTE_PATH.PORTFOLIO_EDIT} element={<PortfolioEditPage/>} />
 								<Route path={ROUTE_PATH.MESSAGE} element={<MessagePage/>} />
+							</Route>
+							<Route path={ROUTE_PATH.LOGIN} element={<LogInPage/>} />
 							</Routes>
-							<Footer />
 						</BrowserRouter>
 						<ToastContainer />
 						<ReactQueryDevtools initialIsOpen={false} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ export default function App() {
 							<Routes>
 								<Route path={ROUTE_PATH.INTRO} element={<IntroPage/>} />
 								<Route path={ROUTE_PATH.MAIN} element={<MainPage/>} />
-								<Route path={ROUTE_PATH.SIGN_IN} element={<SignIn/>} />
+								<Route path={ROUTE_PATH.LOGIN} element={<SignIn/>} />
 								<Route path={ROUTE_PATH.MY_PAGE} element={<MyPage/>} />
 								<Route path={ROUTE_PATH.MY_PAGE_TAB} element={<MyPage/>} />
 								<Route path={ROUTE_PATH.PORTFOLIO_DETAIL} element={<PortfolioDetailPage/>} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,12 +15,12 @@ import { PersistGate } from 'redux-persist/integration/react';
 
 import { Footer, Header, ToastContainer } from '@/components';
 import IntroPage from '@/pages/intro/IntroPage';
+import LogInPage from '@/pages/log-in/LogInPage';
 import MainPage from '@/pages/main/MainPage';
 import MessagePage from '@/pages/message/MessagePage';
 import MyPage from '@/pages/my-page/MyPage';
 import PortfolioDetailPage from '@/pages/portfolio-detail/PortfolioDetailPage';
 import PortfolioEditPage from '@/pages/portfolio-edit/PortfolioEditPage';
-import SignIn from '@/pages/signIn/SignIn';
 import { store } from '@/redux/store';
 import { GlobalErrorFallback } from '@/utils';
 import { ROUTE_PATH } from '@/utils/path';
@@ -36,7 +36,7 @@ export default function App() {
 							<Routes>
 								<Route path={ROUTE_PATH.INTRO} element={<IntroPage/>} />
 								<Route path={ROUTE_PATH.MAIN} element={<MainPage/>} />
-								<Route path={ROUTE_PATH.LOGIN} element={<SignIn/>} />
+								<Route path={ROUTE_PATH.LOGIN} element={<LogInPage/>} />
 								<Route path={ROUTE_PATH.MY_PAGE} element={<MyPage/>} />
 								<Route path={ROUTE_PATH.MY_PAGE_TAB} element={<MyPage/>} />
 								<Route path={ROUTE_PATH.PORTFOLIO_DETAIL} element={<PortfolioDetailPage/>} />

--- a/src/components/molecules/items/commission-item/CommissionItem.tsx
+++ b/src/components/molecules/items/commission-item/CommissionItem.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { Button, CommissionModal, ReviewForm, ReviewItem, Text } from '@/components';
 import * as S from '@/components/molecules/items/commission-item/CommissionItem.styled';
 import { useModal } from '@/hooks';
-import { authority } from '@/redux/loginSlice';
+import { userState } from '@/redux/loginSlice';
 import { eventStopPropagation, toLocalDateString } from '@/utils';
 
 type Props = HTMLAttributes<HTMLDivElement> & {
@@ -15,7 +15,7 @@ type Props = HTMLAttributes<HTMLDivElement> & {
 export default function CommissionItem({ commission, index }: Props) {
 	const [isReviewOpen, setIsReviewOpen] = useState(false);
 
-	const auth = useSelector(authority);
+	const { authority } = useSelector(userState);
 
 	const { handleModal, isModalOpen } = useModal();
 
@@ -33,12 +33,12 @@ export default function CommissionItem({ commission, index }: Props) {
 					<Text type='small'>{commission.client.nickname}</Text>
 					<Text type='small'>{toLocalDateString(new Date(commission.createdAt))}</Text>
 				</S.Box>
-				{ auth === 'expert' && commission.review &&
+				{ authority === 'expert' && commission.review &&
 					<Button color='gray' onClick={handleReviewButton}>
 						{isReviewOpen ? '리뷰 닫기' : '리뷰 확인'}
 					</Button>
 				}
-				{ !isReviewOpen && auth === 'client' && !commission.review &&
+				{ !isReviewOpen && authority === 'client' && !commission.review &&
 					<Button color='gray' onClick={handleReviewButton}>리뷰 작성</Button>
 				}
 			</S.Content>
@@ -47,13 +47,13 @@ export default function CommissionItem({ commission, index }: Props) {
 				<CommissionModal commission={commission} handleModal={handleModal} />
 			}
 
-			{ isReviewOpen && auth === 'expert' &&
+			{ isReviewOpen && authority === 'expert' &&
 				<S.ReviewBox>
 					<ReviewItem review={commission.review}/>
 				</S.ReviewBox>
 			}
 
-			{ isReviewOpen && auth === 'client' && !commission.review &&
+			{ isReviewOpen && authority === 'client' && !commission.review &&
 				<ReviewForm handleReviewOpen={setIsReviewOpen} commission={commission} />
 			}
 		</S.Wrapper>

--- a/src/components/molecules/message/Message.tsx
+++ b/src/components/molecules/message/Message.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { Image, Text } from '@/components';
 import * as S from '@/components/molecules/message/Message.styled';
-import { userId } from '@/redux/loginSlice';
+import { userState } from '@/redux/loginSlice';
 import { toLocalTimeString } from '@/utils';
 
 type Props = {
@@ -11,8 +11,8 @@ type Props = {
 }
 
 export default function Message({ message, partnerProfileImage }: Props) {
-	const loginId = useSelector(userId);
-	const isOwned = message.userId === loginId ? true : false;
+	const { id: userId } = useSelector(userState);
+	const isOwned = message.userId === userId ? true : false;
 
 	return (
 		<S.Wrapper $isOwned={isOwned}>

--- a/src/components/molecules/popper/Popper.styled.tsx
+++ b/src/components/molecules/popper/Popper.styled.tsx
@@ -41,6 +41,15 @@ export const Group = styled.div<{size?: 'fit'}>`
 	${mixins.flexColumn}
 
 	padding: 8px;
+
+	& a {
+		display: flex;
+		gap: 1rem;
+
+		padding: 0.5rem;
+
+		cursor: pointer;
+	}
 `;
 
 export const Item = styled.div`

--- a/src/components/organisms/header/Header.helpers.tsx
+++ b/src/components/organisms/header/Header.helpers.tsx
@@ -8,53 +8,40 @@ const PAGE_SHOW_SEARCH_BAR = ['main', 'profile', 'contact', 'portfolios'];
 const PAGE_SHOW_SECTION_MENU = ['main'];
 
 export const checkIsShowSearchBarPage = (firstPathName: string) => {
-	return PAGE_SHOW_SEARCH_BAR.indexOf(firstPathName) !== -1;
+	return PAGE_SHOW_SEARCH_BAR.indexOf(firstPathName) > -1;
 }
 
 export const checkIsShowSectionMenuPage = (firstPathName: string) => {
-	return PAGE_SHOW_SECTION_MENU.indexOf(firstPathName) !== -1;
+	return PAGE_SHOW_SECTION_MENU.indexOf(firstPathName) > -1;
 }
 
-export const renderHeaderMenuPopper = (isLogin: boolean, userId: number, popOut: ()=>void) => {
-	if(isLogin){
+export const renderHeaderMenuPopper = (user: any, popOut: ()=>void, logout: ()=>void) => {
+	if(user.isLogin){
 		return (
 			<>
 				<S.Group>
-					<S.Item>
-						<S.Box>
-							<Text type='common'>Username</Text>
-							<Text type='small' color='gray'>email</Text>
-						</S.Box>
-					</S.Item>
-				</S.Group>
-				<S.Separator/>
-				<S.Group>
-					<Link to={`/profile/${userId}?tab=bookmarks`}>
-						<S.Item onClick={popOut}>
-							<BookmarkIcon size={20}/>
-							<Text type='common'>북마크</Text>
-						</S.Item>
+					<Link to={`/profile/${user.id}?tab=bookmarks`} onClick={popOut}>
+						<BookmarkIcon size={20}/>
+						<Text type='common'>북마크</Text>
 					</Link>
 
-					<Link to={`/profile/${userId}`}>
-						<S.Item onClick={popOut}>
-							<UserIcon size={20}/>
-							<Text type='common'>내 정보</Text>
-						</S.Item>
+					<Link to={`/profile/${user.id}`} onClick={popOut}>
+						<UserIcon size={20}/>
+						<Text type='common'>내 정보</Text>
 					</Link>
 
-					<Link to={`/messages`}>
-						<S.Item onClick={popOut}>
-							<MessageIcon size={20}/>
-							<Text type='common'>메시지</Text>
-						</S.Item>
+					<Link to={`/messages`} onClick={popOut}>
+						<MessageIcon size={20}/>
+						<Text type='common'>메시지</Text>
 					</Link>
 				</S.Group>
+
 				<S.Separator/>
+
 				<S.Group>
-					<S.Item onClick={popOut}>
-					<Text type='common'>로그아웃</Text>
-					</S.Item>
+					<Link to={`/main/android-ios`} onClick={logout}>
+						<Text type='common'>로그아웃</Text>
+					</Link>
 				</S.Group>
 			</>
 		)
@@ -62,10 +49,10 @@ export const renderHeaderMenuPopper = (isLogin: boolean, userId: number, popOut:
 
 	return (
 		<S.Group>
-			<S.Item>
+			<Link to={`/login`} onClick={popOut}>
 				<BookmarkIcon size={20}/>
 				<Text type='common'>북마크</Text>
-			</S.Item>
+			</Link>
 		</S.Group>
 	)
 }

--- a/src/components/organisms/header/Header.tsx
+++ b/src/components/organisms/header/Header.tsx
@@ -1,5 +1,5 @@
 import { FiMenu as MenuIcon} from "react-icons/fi";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
 import Logo from '@/assets/images/logo.png';
@@ -7,7 +7,7 @@ import { Image, Button, SectionNavigator, Popper, SearchBar, SearchModal } from 
 import { renderHeaderMenuPopper } from "@/components/organisms/header/Header.helpers";
 import * as S from "@/components/organisms/header/Header.styled";
 import { useHeader, useModal, usePopup } from "@/hooks";
-import { isLogin as IsLogin, userId as UserId } from "@/redux/loginSlice";
+import { logout, userState } from "@/redux/loginSlice";
 import { ROUTE_PATH } from "@/utils";
 
 export default function Header() {
@@ -16,9 +16,14 @@ export default function Header() {
 	const { isModalOpen, handleModal } = useModal();
 
 	const navigate = useNavigate();
+	const dispatch = useDispatch();
 
-	const isLogin = useSelector(IsLogin);
-	const userId = useSelector(UserId);
+	const user = useSelector(userState);
+
+	const handleLogOut = () => {
+		dispatch(logout());
+		popOut();
+	};
 
 	return(
 		<S.Wrapper>
@@ -40,7 +45,7 @@ export default function Header() {
 				<div></div>
 			}
 
-			{ isLogin ?
+			{ user.isLogin ?
 				<S.ButtonGroup>
 					<Button color='black' shape='square' onClick={()=>navigate(ROUTE_PATH.PORTFOLIO_EDIT)}>Upload</Button>
 					<Button color='transparent' shape='square' onClick={popUp}>
@@ -50,15 +55,14 @@ export default function Header() {
 				</S.ButtonGroup>
 				:
 				<S.ButtonGroup>
-					<Button color='white' shape='square' onClick={()=>navigate(ROUTE_PATH.SIGN_IN)}>Log in</Button>
-					<Button color='black' shape='square' onClick={()=>navigate(ROUTE_PATH.TRIAL_LOGIN)}>Start Trial Version</Button>
+					<Button color='black' shape='square' onClick={()=>navigate(ROUTE_PATH.LOGIN)}>Start Trial Version</Button>
 					<Button color='transparent' shape='round' onClick={popUp}><MenuIcon size={15}/></Button>
 				</S.ButtonGroup>
 			}
 
 			{ isPopUp &&
 				<Popper coordinate={coordinate} popOut={popOut}>
-					{renderHeaderMenuPopper(isLogin, userId, popOut)}
+					{renderHeaderMenuPopper(user, popOut, handleLogOut)}
 				</Popper>
 			}
 		</S.Wrapper>

--- a/src/components/organisms/modal/commission-modal/CommissionModal.tsx
+++ b/src/components/organisms/modal/commission-modal/CommissionModal.tsx
@@ -8,7 +8,7 @@ import * as S from "./CommissionModal.styled";
 
 import { Text, Button, Modal, Profile, Rating } from "@/components";
 import { useStopScrollY } from "@/hooks";
-import { authority } from "@/redux/loginSlice";
+import { userState } from "@/redux/loginSlice";
 import { addValidationErrorToast } from "@/utils";
 import { usePostCommissionQuery } from "@/utils/api-service/commission";
 
@@ -38,7 +38,7 @@ export default function RequestModal({ commission, handleModal, editMode }: Prop
 
 	const dispatch = useDispatch();
 
-	const auth = useSelector(authority);
+	const { authority } = useSelector(userState);
 
 	const { register, reset, handleSubmit, formState: { isSubmitting, errors, dirtyFields } } = useForm<FormValues>({
 		mode: 'onSubmit',
@@ -169,10 +169,10 @@ export default function RequestModal({ commission, handleModal, editMode }: Prop
 			</S.Content>
 
 			<S.ButtonGroup>
-				{ auth === 'expert' && !isEditMode &&
+				{ authority === 'expert' && !isEditMode &&
 					<Button color='black' size='medium' shape='square' onClick={() => setIsEditMode(prev=>!prev)}>의뢰 수정</Button>
 				}
-				{ auth === 'client' && commission.details.state !== '구매 확정' &&
+				{ authority === 'client' && commission.details.state !== '구매 확정' &&
 					<Button color='black' size='medium' shape='square'>주문 취소</Button>
 				}
 				{ isEditMode ?

--- a/src/components/organisms/partner-profile/PartnerProfile.tsx
+++ b/src/components/organisms/partner-profile/PartnerProfile.tsx
@@ -4,7 +4,7 @@ import { useSelector } from "react-redux";
 import { Text, Button, Profile, CommissionModal } from "@/components";
 import * as S from "@/components/organisms/partner-profile/PartnerProfile.styled";
 import { useModal } from "@/hooks";
-import { authority } from "@/redux/loginSlice";
+import { userState } from "@/redux/loginSlice";
 import { toLocalDateString } from "@/utils";
 
 type Props = {
@@ -14,7 +14,7 @@ type Props = {
 export default function PartnerProfile({ message }: Props) {
 	const queryClient = useQueryClient();
 
-	const auth = useSelector(authority);
+	const { authority } = useSelector(userState);
 	const { isModalOpen, handleModal} = useModal();
 	const messageQuery = queryClient.getQueryData(['message', `${message.clientId}`]) as any;
 
@@ -45,7 +45,7 @@ export default function PartnerProfile({ message }: Props) {
 			<Text type='label'>전문가 서비스</Text>
 			<Profile type='portfolio' user={message.portfolio} />
 
-			{ !message.commission && auth === 'expert' &&
+			{ !message.commission && authority === 'expert' &&
 				<Button color='black' size='full' onClick={handleModal}>의뢰 폼 전송</Button>
 			}
 
@@ -53,7 +53,7 @@ export default function PartnerProfile({ message }: Props) {
 				<Button color='gray' size='full' onClick={handleModal}>의뢰 폼 확인</Button>
 			}
 
-			{ isModalOpen && !message.commission && auth === 'expert' &&
+			{ isModalOpen && !message.commission && authority === 'expert' &&
 				<CommissionModal commission={initialCommission} handleModal={handleModal} editMode />
 			}
 			{ isModalOpen && message.commission &&

--- a/src/components/organisms/tracking/Tracking.tsx
+++ b/src/components/organisms/tracking/Tracking.tsx
@@ -5,7 +5,7 @@ import { countCommissionStatus } from './Tracking.helpers';
 import { ProcessIcon, FolderIcon, CancelIcon } from '@/assets/images';
 import { Image, Text } from "@/components";
 import * as S from "@/components/organisms/tracking/Tracking.styled";
-import { authority } from '@/redux/loginSlice';
+import { userState } from '@/redux/loginSlice';
 
 type Props = {
 	commissions: any;
@@ -14,7 +14,7 @@ type Props = {
 export default function Tracking({ commissions }: Props) {
 	const commissionsStatus = countCommissionStatus(commissions);
 
-	const auth = useSelector(authority);
+	const { authority } = useSelector(userState);
 
 	return(
 		<S.Wrapper>
@@ -49,7 +49,7 @@ export default function Tracking({ commissions }: Props) {
 						<Text type='common'>{commissionsStatus['구매 확정']}</Text>
 					</S.Group>
 
-					{ auth === 'expert' ?
+					{ authority === 'expert' ?
 						<S.Group>
 							<Text type='common'>작성된 리뷰</Text>
 							<Text type='common'>{commissionsStatus['작성된 리뷰']}</Text>

--- a/src/pages/log-in/LogInPage.styled.tsx
+++ b/src/pages/log-in/LogInPage.styled.tsx
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.main`
+
+`;

--- a/src/pages/log-in/LogInPage.styled.tsx
+++ b/src/pages/log-in/LogInPage.styled.tsx
@@ -1,5 +1,46 @@
 import styled from "styled-components";
 
-export const Wrapper = styled.main`
+import * as mixins from '@/styles/mixins';
 
+export const Wrapper = styled.main`
+	width: 100%;
+	height: 100vh;
+
+	display: flex;
+
+	padding: 0;
+`;
+
+export const LoginSection = styled.section`
+	width: 50%;
+	height: 100%;
+
+	${mixins.flexCenter}
+	${mixins.flexColumn}
+	gap: 2rem;
+`;
+
+export const ImageSection = styled.section`
+	width: 50%;
+	height: 100%;
+
+	background-color: black;
+`;
+
+export const ButtonGroup = styled.div`
+	width: 28rem;
+
+	${mixins.flexColumn}
+	gap: 2.8rem;
+
+	padding: 2rem;
+	padding: 3rem 3rem;
+
+	border: 1px solid gray;
+	border-radius: 2rem;
+`;
+
+export const Box = styled.div`
+	${mixins.flexColumn}
+	gap: 1rem;
 `;

--- a/src/pages/log-in/LogInPage.tsx
+++ b/src/pages/log-in/LogInPage.tsx
@@ -1,9 +1,47 @@
+import { useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+
+import Logo from '@/assets/images/logo.png';
+import { Button, Image, Text } from '@/components';
 import * as S from '@/pages/log-in/LogInPage.styled';
+import { login } from '@/redux/loginSlice';
 
 export default function LogIn(){
+
+	const dispatch = useDispatch();
+	const navigate = useNavigate();
+
+	const loginByTrial = (authority: 'expert' | 'client') => {
+		dispatch(login(authority));
+		navigate('/main/android-ios');
+	};
+
 	return(
 		<S.Wrapper>
-		<h1>SignIn</h1>
+			<S.LoginSection>
+				<Image src={Logo} size='2.8rem' />
+				<Text type='title'>Welcome</Text>
+
+				<S.ButtonGroup>
+					<S.Box>
+						<Text type='label'>서비스를 의뢰하고 싶다면</Text>
+						<Button size='full' color='transparent' onClick={() => loginByTrial('client')}>
+							의뢰인으로 가입
+						</Button>
+					</S.Box>
+
+					<S.Box>
+						<Text type='label'>전문성을 판매하고 싶다면</Text>
+						<Button size='full' color='transparent' onClick={() => loginByTrial('expert')}>
+							전문가로 가입
+						</Button>
+					</S.Box>
+				</S.ButtonGroup>
+			</S.LoginSection>
+
+			<S.ImageSection>
+
+			</S.ImageSection>
 		</S.Wrapper>
 	)
 }

--- a/src/pages/log-in/LogInPage.tsx
+++ b/src/pages/log-in/LogInPage.tsx
@@ -1,0 +1,9 @@
+import * as S from '@/pages/log-in/LogInPage.styled';
+
+export default function LogIn(){
+	return(
+		<S.Wrapper>
+		<h1>SignIn</h1>
+		</S.Wrapper>
+	)
+}

--- a/src/pages/main-layout/MainLayout.tsx
+++ b/src/pages/main-layout/MainLayout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+
+import { Footer, Header } from '@/components';
+
+export default function MainLayout() {
+  return (
+    <>
+      <Header />
+      <Outlet />
+      <Footer />
+    </>
+  );
+}

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -5,7 +5,7 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import { Button, ActivityInformation, MyPageNavigator, Profile } from "@/components";
 import { renderDescription } from "@/pages/my-page/MyPage.helpers";
 import * as S from "@/pages/my-page/MyPage.styled";
-import { userId as userID } from "@/redux/loginSlice";
+import { userState } from "@/redux/loginSlice";
 import { useUserQuery } from "@/utils";
 
 export type Navigation = 'introduce' | 'portfolios' | 'review' | 'management' | 'bookmarks';
@@ -17,8 +17,8 @@ function MyPage(){
 
 	const params = useParams();
 	const profileId = params.id as string;
-	const loginId = useSelector(userID);
-	const isMyPage = profileId === String(loginId) ? true : false;
+	const { id: userId } = useSelector(userState);
+	const isMyPage = profileId === String(userId) ? true : false;
 
 	const { data: user } = useUserQuery(profileId);
 

--- a/src/pages/portfolio-detail/PortfolioDetailPage.tsx
+++ b/src/pages/portfolio-detail/PortfolioDetailPage.tsx
@@ -7,7 +7,7 @@ import * as S from "./PortfolioDetailPage.styled";
 
 import { Text, Image, Button, ToggleButton, Tag, Profile, AlertModal } from "@/components";
 import { useModal, useHtmlContent } from "@/hooks";
-import { userId } from "@/redux/loginSlice";
+import { userState } from "@/redux/loginSlice";
 import { section } from "@/redux/sectionSlice";
 import { Portfolio } from "@/types";
 import { usePortfolioDeleteQuery, usePortfolioDetailQuery, stringToUrlParameter } from "@/utils";
@@ -15,7 +15,7 @@ import { usePortfolioDeleteQuery, usePortfolioDetailQuery, stringToUrlParameter 
 export default function PortfolioDetail(){
 	const [hasAuthority, setHasAuthority] = useState(false);
 
-	const user = useSelector(userId);
+	const user = useSelector(userState);
 
 	const portfolioId = useParams().portfolio_id as string;
 	const { data: portfolio } = usePortfolioDetailQuery(portfolioId);
@@ -37,7 +37,7 @@ export default function PortfolioDetail(){
 
 	useEffect(() => {
 		if(portfolio) {
-			const hasAuthority = (user === portfolio.user.id) ? true : false;
+			const hasAuthority = (user.id === portfolio.user.id) ? true : false;
 			setHasAuthority(hasAuthority);
 		}
 	}, [portfolio])

--- a/src/pages/signIn/SignIn.tsx
+++ b/src/pages/signIn/SignIn.tsx
@@ -1,9 +1,0 @@
-function SignIn(){
-    return(
-        <>
-        <h1>SignIn</h1>
-        </>
-    )
-}
-
-export default SignIn;

--- a/src/pages/signUp/SignUp.tsx
+++ b/src/pages/signUp/SignUp.tsx
@@ -1,9 +1,0 @@
-function SignUp(){
-    return(
-        <>
-        <h1>SignUp</h1>
-        </>
-    )
-}
-
-export default SignUp;

--- a/src/redux/loginSlice.ts
+++ b/src/redux/loginSlice.ts
@@ -15,7 +15,7 @@ const initialState: InitialState = {
 };
 
 export const loginSlice = createSlice({
-	name: "login",
+	name: "user",
 	initialState,
 	reducers: {
 		login: (state, action) => {
@@ -24,7 +24,9 @@ export const loginSlice = createSlice({
 			state.id = action.payload === 'expert' ? 1 : 100;
 		},
 		logout: (state) => {
-			state = initialState;
+			state.authority = null;
+			state.isLogin = false;
+			state.id = null;
 		},
 	},
 });

--- a/src/redux/loginSlice.ts
+++ b/src/redux/loginSlice.ts
@@ -3,33 +3,33 @@ import { createSlice } from '@reduxjs/toolkit';
 import { RootState } from './store';
 
 type InitialState = {
-	authority: 'expert' | 'client',
-	isLogin: boolean,
-	userId: number,
+	id: number | null;
+	isLogin: boolean;
+	authority: 'expert' | 'client' | null;
 }
 
 const initialState: InitialState = {
-	authority: 'expert',
-	isLogin: true,
-	userId: 1,
+	id: null,
+	isLogin: false,
+	authority: null,
 };
 
 export const loginSlice = createSlice({
-    name: "login",
-    initialState,
-    reducers: {
-        login: (state, action) => {
-            state = action.payload;
-        },
-				logout: (state) => {
-					state = initialState;
-				},
-    },
+	name: "login",
+	initialState,
+	reducers: {
+		login: (state, action) => {
+			state.authority = action.payload;
+			state.isLogin = true;
+			state.id = action.payload === 'expert' ? 1 : 100;
+		},
+		logout: (state) => {
+			state = initialState;
+		},
+	},
 });
 
-export const { actions, reducer } = loginSlice;
-export const isLogin = (state: RootState) => state.auth.isLogin;
-export const userId = (state: RootState) => state.auth.userId;
-export const authority = (state: RootState) => state.auth.authority;
+export const { login, logout } = loginSlice.actions;
+export const userState = (state: RootState) => state.user;
 
 export default loginSlice;

--- a/src/redux/sectionSlice.ts
+++ b/src/redux/sectionSlice.ts
@@ -23,7 +23,6 @@ export const sectionSlice = createSlice({
 	},
 });
 
-export const { actions, reducer } = sectionSlice;
 export const section = (state: RootState) => state.section.section;
 export const { setSection } = sectionSlice.actions;
 

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -6,15 +6,22 @@ import loginSlice from '@/redux/loginSlice';
 import sectionSlice from '@/redux/sectionSlice';
 import toastSlice from '@/redux/toastSlice';
 
-const persistConfig = {
-	key: 'root',
+
+const authPersistConfig = {
+	key: 'user',
 	storage,
-	whitelist: ['user', 'section'],
+	whitelist: ['id', 'isLogin', 'authority'],
+};
+
+const sectionPersistConfig = {
+	key: 'section',
+	storage,
+	whitelist: ['section'],
 }
 
 const rootReducer = combineReducers({
-	user: persistReducer(persistConfig, loginSlice.reducer),
-	section: persistReducer(persistConfig, sectionSlice.reducer),
+	user: persistReducer(authPersistConfig, loginSlice.reducer),
+	section: persistReducer(sectionPersistConfig, sectionSlice.reducer),
 	toast: toastSlice.reducer,
 });
 

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -2,26 +2,19 @@ import { combineReducers, configureStore, getDefaultMiddleware } from '@reduxjs/
 import { persistReducer } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 
-import sectionSlice from './sectionSlice';
-import toastSlice from './toastSlice';
-
 import loginSlice from '@/redux/loginSlice';
+import sectionSlice from '@/redux/sectionSlice';
+import toastSlice from '@/redux/toastSlice';
 
-const authPersistConfig = {
-	key: 'auth',
+const persistConfig = {
+	key: 'root',
 	storage,
-	whitelist: ['user'],
-};
-
-const sectionPersistConfig = {
-	key: 'section',
-	storage,
-	whitelist: ['section'],
+	whitelist: ['user', 'section'],
 }
 
 const rootReducer = combineReducers({
-	auth: persistReducer(authPersistConfig, loginSlice.reducer),
-	section: persistReducer(sectionPersistConfig, sectionSlice.reducer),
+	user: persistReducer(persistConfig, loginSlice.reducer),
+	section: persistReducer(persistConfig, sectionSlice.reducer),
 	toast: toastSlice.reducer,
 });
 

--- a/src/redux/toastSlice.ts
+++ b/src/redux/toastSlice.ts
@@ -25,7 +25,6 @@ export const toastSlice = createSlice({
   },
 });
 
-export const { actions, reducer } = toastSlice;
 export const { setToast, deleteToast } = toastSlice.actions;
 export const toasts = (state: RootState) => state.toast.toasts;
 export default toastSlice;

--- a/src/utils/api-service/commission.ts
+++ b/src/utils/api-service/commission.ts
@@ -1,14 +1,14 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useSelector } from "react-redux";
 
-import { userId as UserId} from "@/redux/loginSlice";
+import { userState } from "@/redux/loginSlice";
 import { fetch } from '@/utils'
 
 export const usePostCommissionQuery = (commissionId?: number, clientId?: number) => {
 	const queryClient = useQueryClient();
 
-	const userId = String(useSelector(UserId));
-	const user = queryClient.getQueryData(['user', userId]) as any;
+	const { id: userId } = useSelector(userState);
+	const user = queryClient.getQueryData(['user', `${userId}`]) as any;
 	const message = queryClient.getQueryData(['message', `${clientId}`]) as any;
 
 	const addCommission = (body: any) => fetch(`/commissions?portfolio_id=${message.portfolioId}&client_id=${message.clientId}`, 'POST', body);
@@ -19,7 +19,7 @@ export const usePostCommissionQuery = (commissionId?: number, clientId?: number)
 		onSuccess: (response: any) => {
 
 			if(commissionId && user) {
-				queryClient.setQueryData(['user', userId], () => {
+				queryClient.setQueryData(['user', `${userId}`], () => {
 					const commission = user.activity.commissions.find((commission: any) => {
 						return commission.id === commissionId;
 					})
@@ -41,15 +41,15 @@ export const usePostCommissionQuery = (commissionId?: number, clientId?: number)
 
 export const useReviewPostQuery = (id: number) => {
 	const queryClient = useQueryClient();
-	const userId = String(useSelector(UserId));
-	const user = queryClient.getQueryData(['user', userId]) as any;
+	const { id: userId } = useSelector(userState);
+	const user = queryClient.getQueryData(['user', `${userId}`]) as any;
 
 	const postReview = (body: any) => fetch(`/reviews?id=${id}`, 'POST', body)
 
 	return useMutation({
 		mutationFn: postReview,
 		onSuccess: (response: any) => {
-			queryClient.setQueryData(['user', userId], () => {
+			queryClient.setQueryData(['user', `${userId}`], () => {
 				const commission = user.activity.commissions.find((commission: any) => {
 					return commission.id === id;
 				});

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -3,8 +3,7 @@ import { ISectionFactory } from "@/types";
 export const ROUTE_PATH = {
 	INTRO: '/',
 	MAIN: '/main/:section',
-	SIGN_IN: '/login',
-	TRIAL_LOGIN: '/trial',
+	LOGIN: '/login',
 	MY_PAGE: '/profile/:id',
 	MY_PAGE_TAB: '/profile/:id/:tab',
 	PORTFOLIO_DETAIL: '/portfolios/:portfolio_id',


### PR DESCRIPTION
## 개요
체험용 로그인/로그아웃 기능을 구현합니다.

## 작업사항
* LoginPage.tsx 페이지를 생성한다.
* loginSlice 상태값이 새로고침되어도 초기화되지 않도록 redux-persist를 적용한다.
* 로그아웃 시 메인 섹션 페이지로 이동한다.

## 변경 로직
* loginSlice 상태값을 userState 객체 하나로 export 한다.
  * 기존에는 isLogin, id, authority 각각 따로 useSelect 함

### 변경후

https://github.com/Kim-DaHam/Portfolly/assets/81691456/eb30fe0b-f70b-41b8-ad5d-5e82086c7d50

