### PR TITLE
Fix: PortfolioList.tsx 무한 스크롤 에러를 해결한다

### DIFF
--- a/src/components/organisms/portfolio-list/PortfolioItemList.styled.ts
+++ b/src/components/organisms/portfolio-list/PortfolioItemList.styled.ts
@@ -1,5 +1,8 @@
 import styled from "styled-components";
 
+export const Wrapper = styled.div`
+`;
+
 export const GridBox = styled.div`
 	width: 100%;
 	height: 100%;
@@ -18,4 +21,10 @@ export const Notification = styled.div`
 	align-items: center;
 
 	padding-top: 5rem;
+`;
+
+export const ObserveDiv = styled.div`
+	width: 100%;
+	height: 1px;
+	margin-top: 9rem;
 `;

--- a/src/components/organisms/portfolio-list/PortfolioItemList.tsx
+++ b/src/components/organisms/portfolio-list/PortfolioItemList.tsx
@@ -3,7 +3,8 @@ import { useSelector } from "react-redux";
 
 import * as S from "@/components/organisms/portfolio-list/PortfolioItemList.styled";
 import { section } from "@/redux/sectionSlice";
-import { Portfolio } from "@/types";
+
+import type { Portfolio } from "@/types";
 
 import { useIntersectionObserver } from "@/hooks";
 import { usePortfoliosQuery } from "@/utils";
@@ -14,40 +15,32 @@ type Props = {
 	category: string;
 };
 
-const ITEMS_PER_SHOW = 10;
+const ITEMS_PER_SHOW = 6;
+
 export const SESSION_STORAGE_KEY = "lastClickedPortfolio";
 
-export default function PortfolioItemList({category}: Props) {
-	const [count, setCount] = useState(ITEMS_PER_SHOW);
-	const [loadData, setLoadData] = useState(true);
+export default function PortfolioItemList({ category }: Props) {
+	const [showsNum, setShowsNum] = useState<number>(ITEMS_PER_SHOW);
 
 	const currentSection = useSelector(section);
 
 	const {
 		data: portfolios,
-		fetchNextPage, hasNextPage
+		fetchNextPage,
+		hasNextPage,
 	} = usePortfoliosQuery(
 		currentSection,
 		{
 			filterKey: 'category',
-			filterValue: category
+			filterValue: category,
 		}
 	);
 
 	const loadNextPage = () => {
-		const allPortfoliosCount = portfolios ? portfolios.length : 0;
-		const isOnePageLoaded = (count === allPortfoliosCount) ? true : false;
-
-		if(isOnePageLoaded && !hasNextPage) {
-			setLoadData(false);
-			return;
-		}
-
-		if(isOnePageLoaded && hasNextPage) {
+		if(hasNextPage) {
 			fetchNextPage();
 		}
-		setCount(prev => prev + ITEMS_PER_SHOW);
-	}
+	};
 
 	const setObservationTarget = useIntersectionObserver(loadNextPage);
 
@@ -63,7 +56,6 @@ export default function PortfolioItemList({category}: Props) {
 		if(!getStorage) return;
 
 		const { anchorPosition } = JSON.parse(getStorage);
-
 		setTimeout(() => {
       window.scrollTo({
         top: anchorPosition,
@@ -72,29 +64,42 @@ export default function PortfolioItemList({category}: Props) {
 		return () => sessionStorage.removeItem(SESSION_STORAGE_KEY);
 	}, []);
 
+	useEffect(() => {
+		const isLastPortfoliosLessThanPerShows = showsNum + ITEMS_PER_SHOW > portfolios.length;
+
+		if(isLastPortfoliosLessThanPerShows) {
+			setShowsNum(prev => prev + (portfolios.length - showsNum));
+			return;
+		}
+		setShowsNum(prev => prev + ITEMS_PER_SHOW);
+	}, [portfolios]);
+
 	return (
-		<S.GridBox>
-			{ portfolios.length > 0 ?
-				portfolios.map((portfolio: Portfolio, index: number)=>{
-					if(index < count) {
-						return(
-							<PortfolioCard
-								key={index}
-								portfolio={portfolio}
-								onClick={() => saveScroll(++index)}
-							/>
-						)
-				}})
-				:
-				<S.Notification>
-					<Text size='bodyLarge' color='lightgray'>
-						해당하는 아이템이 없습니다.
-					</Text>
-				</S.Notification>
+		<S.Wrapper>
+			<S.GridBox>
+				{ portfolios?.length > 0 ?
+					portfolios.map((portfolio: Portfolio, index: number)=>{
+						if(index < showsNum) {
+							return(
+								<PortfolioCard
+									key={index}
+									portfolio={portfolio}
+									onClick={() => saveScroll(++index)}
+								/>
+							)
+					}})
+					:
+					<S.Notification>
+						<Text size='bodyLarge' color='lightgray'>
+							해당하는 아이템이 없습니다.
+						</Text>
+					</S.Notification>
+				}
+			</S.GridBox>
+
+			{ hasNextPage &&
+				<S.ObserveDiv ref={setObservationTarget}></S.ObserveDiv>
 			}
-			{ loadData &&
-				<div ref={setObservationTarget}></div>
-			}
-		</S.GridBox>
+		</S.Wrapper>
 	)
 }

--- a/src/hooks/event/useIntersectionObserver.tsx
+++ b/src/hooks/event/useIntersectionObserver.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-function useIntersectionObserver(onIntersect: ()=>void) {
+export default function useIntersectionObserver(onIntersect: ()=>void) {
 	const [observationTarget, setObservationTarget] = useState<HTMLElement | null>(null);
 
 	const observer = useRef(
@@ -28,5 +28,3 @@ function useIntersectionObserver(onIntersect: ()=>void) {
 
 	return setObservationTarget;
 }
-
-export default useIntersectionObserver;


### PR DESCRIPTION
## 개요
`PortfolioList.tsx` 무한 스크롤이 다음 페이지 데이터를 불러오지 않는 문제를 해결합니다.

## 작업사항
* `/mocks/handler/portfolio.ts` api 핸들러 코드를 수정한다.
  * no-sql 데이터 형식에 맞춰 작동하도록 수정한다.
  * 데이터 목록을 map으로 바로 불러오기 위해 key-value 형태를 Array[]로 바꾼다.
  * 각 포트폴리오의 id역할을 하는 key는 `portfolios[docKey].id = docKey` 로 하여금 새 요소로 넣는다.

## 변경로직
* `useIntersectionObserver` 훅에 초기값으로 들어가는 callback 함수는 `fetchNextPage()`만 실행시키게 한다.
* 그 외 상태값을 조작하는 로직은 `useEffect(()=>void, [portfolios])` 훅 안에서 처리한다.
* useSuspenseInfiniteQuery의 반환 데이터를 다음과 같이 1차원 배열로 변경해서 받는다.
  * `select: data => data.pages.flat()`

### 변경후

https://github.com/Kim-DaHam/Portfolly/assets/81691456/3b653012-654c-4c83-90e7-0e36de37e257

총 데이터는 30개, 한 페이지당 10개씩 불러오며 화면에는 6개씩 끊어 보여줍니다.

10개 데이터를 화면에 전부 그렸을 경우 다음 페이지 데이터를 불러옵니다.

page가 3에 도달했을 때 마지막 데이터 반환값은 `[]`이고, 더이상 데이터가 fetch되지 않습니다.
