### PR TITLE
Feat: PortfolioDetail.tsx 페이지 Api 에러 처리를 추가한다

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -30,6 +30,10 @@ module.exports = {
             "pattern": "@/utils",
             "group": "unknown",
           },
+					{
+            "pattern": "@/redux",
+            "group": "unknown",
+          },
           {
             "pattern": "@/pages",
             "group": "unknown",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ import PortfolioEditPage from '@/pages/portfolio-edit/PortfolioEditPage';
 import { store } from '@/redux/store';
 import { ROUTE_PATH } from '@/utils/path';
 
-import { GlobalErrorFallback , ToastContainer } from '@/components';
+import { GlobalErrorFallback, AlertContainer, ToastContainer } from '@/components';
 
 import '@/styles/GlobalFonts.css';
 
@@ -53,6 +53,7 @@ export default function App() {
 							</Routes>
 						</BrowserRouter>
 						<ToastContainer />
+						<AlertContainer />
 						<ReactQueryDevtools initialIsOpen={false} />
 					</QueryClientProvider>
 				</PersistGate>

--- a/src/components/atoms/button/ToggleButton.tsx
+++ b/src/components/atoms/button/ToggleButton.tsx
@@ -61,7 +61,6 @@ export default function ToggleButton({type, portfolioId, isToggled, currentLikes
 
 	const handleToggleButton = () => {
 		toggleButtonMutation.mutate();
-		console.log(type, isToggled)
 		if(isToggled) {
 			setColor('white');
 			return;

--- a/src/components/atoms/button/ToggleButton.tsx
+++ b/src/components/atoms/button/ToggleButton.tsx
@@ -2,7 +2,8 @@ import { useState } from "react";
 import { FiBookmark as BookmarkIcon, FiHeart as LikeIcon } from "react-icons/fi";
 
 import { Text, Button } from "@/components/atoms/index";
-import { IComponentFactory } from "@/types";
+
+import type { IComponentFactory } from "@/types";
 
 import { useToggleButtonQuery } from "@/utils";
 
@@ -10,7 +11,7 @@ export type Toggle = 'bookmark' | 'like';
 
 type Props = {
 	type: Toggle;
-	portfolioId: number;
+	portfolioId: string;
 	isToggled: boolean;
 	currentLikes?: number;
 };
@@ -20,7 +21,12 @@ const buttonColor: {[key in Toggle]: string} = {
 	bookmark: '#ffeb54',
 };
 
-const renderToggleButton = (type: Toggle, color: string, currentLikes: number, handleToggleButton: ()=>void) => {
+const renderToggleButton = (
+	type: Toggle,
+	color: string,
+	currentLikes: number,
+	handleToggleButton: ()=>void
+) => {
 	const ComponentFactory: IComponentFactory = {
 		bookmark: (
 			<Button color='black' onClick={handleToggleButton}>
@@ -55,13 +61,13 @@ export default function ToggleButton({type, portfolioId, isToggled, currentLikes
 
 	const handleToggleButton = () => {
 		toggleButtonMutation.mutate();
+		console.log(type, isToggled)
 		if(isToggled) {
 			setColor('white');
+			return;
 		}
-		if(!isToggled) {
-			setColor(buttonColor[type]);
-		}
-	}
+		setColor(buttonColor[type]);
+	};
 
 	return(
 		<>

--- a/src/components/atoms/image/Image.styled.tsx
+++ b/src/components/atoms/image/Image.styled.tsx
@@ -9,6 +9,7 @@ export const ImageLayout = styled.div<Props>`
 
 	flex: none;
 	overflow: hidden;
+	background-color: #f3f3f3;
 
 	${(props) => {
 		if(props.shape === 'circle'){

--- a/src/components/molecules/alert-container/AlertContainer.tsx
+++ b/src/components/molecules/alert-container/AlertContainer.tsx
@@ -1,0 +1,35 @@
+import { Fragment, useEffect } from "react";
+import { useSelector } from "react-redux";
+
+import { alertState } from "@/redux/alertSlice";
+
+import { useModal } from "@/hooks";
+
+import { AlertModal } from "@/components";
+
+export default function AlertContainer() {
+	const { isModalOpen, handleModal } = useModal();
+	const alert = useSelector(alertState);
+
+	const onConfirm = () => {
+		alert?.onConfirm();
+		handleModal();
+	};
+
+	useEffect(() => {
+		if(alert) {
+			handleModal();
+		}
+	}, [alert]);
+
+	if(!alert) return null;
+
+	return (
+		<AlertModal
+			type={alert.type}
+			onConfirm={onConfirm}
+			handleModal={handleModal}
+			$modalState={isModalOpen}
+		/>
+	)
+}

--- a/src/components/molecules/alert-container/AlertContainer.tsx
+++ b/src/components/molecules/alert-container/AlertContainer.tsx
@@ -1,19 +1,21 @@
-import { Fragment, useEffect } from "react";
-import { useSelector } from "react-redux";
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
-import { alertState } from "@/redux/alertSlice";
+import { alertState, deleteAlert } from "@/redux/alertSlice";
 
 import { useModal } from "@/hooks";
 
 import { AlertModal } from "@/components";
 
 export default function AlertContainer() {
+	const dispatch = useDispatch();
 	const { isModalOpen, handleModal } = useModal();
 	const alert = useSelector(alertState);
 
 	const onConfirm = () => {
 		alert?.onConfirm();
 		handleModal();
+		dispatch(deleteAlert);
 	};
 
 	useEffect(() => {

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -1,3 +1,4 @@
+import AlertContainer from "@/components/molecules/alert-container/AlertContainer";
 import QuillEditor from "@/components/molecules/editor/QuillEditor";
 import CommissionItem from "@/components/molecules/items/commission-item/CommissionItem";
 import MessageRoomItem from "@/components/molecules/items/messageRoom-item/MessageRoomItem";
@@ -34,4 +35,5 @@ export {
 	MessageRoomItem,
 	ReviewForm,
 	Message,
+	AlertContainer,
 };

--- a/src/components/organisms/modal/alert-modal/AlertModal.tsx
+++ b/src/components/organisms/modal/alert-modal/AlertModal.tsx
@@ -70,7 +70,7 @@ export default function AlertModal({type, $modalState, handleModal, onConfirm}: 
 						size='medium'
 						onClick={handleModal}
 					>
-						취소하기
+						취소
 					</Button>
 				</ButtonGroup>
 			</Content>

--- a/src/components/organisms/modal/alert-modal/AlertModal.tsx
+++ b/src/components/organisms/modal/alert-modal/AlertModal.tsx
@@ -1,22 +1,20 @@
-import { HTMLAttributes, MouseEventHandler } from "react";
+import { MouseEventHandler } from "react";
 import styled from "styled-components";
 
 import * as mixins from '@/styles/mixins';
 
-import type { IComponentFactory } from "@/types";
+import type { IComponentFactory, AlertModal } from "@/types";
 
 import { Text, Button, Modal } from "@/components";
 
-type Alert = 'delete' | 'cancel' | 'messageRoom';
-
 type Props = {
-	type: Alert;
+	type: AlertModal;
 	$modalState: boolean;
 	handleModal: MouseEventHandler<HTMLElement>;
 	onConfirm: () => void;
 };
 
-export const renderAlertMessage = (type: Alert)=>{
+export const renderAlertMessage = (type: AlertModal)=>{
 	const ComponentFactory: IComponentFactory = {
 		delete: (
 			<Text size='bodyMedium'>정말 삭제하시겠습니까?</Text>
@@ -35,15 +33,23 @@ export const renderAlertMessage = (type: Alert)=>{
 				지금까지의 대화 내용은 저장되지 않습니다.
 			</Text>
 		),
+		error: (
+			<Text size='bodyMedium'>
+				페이지를 불러올 수 없습니다.
+				<br/>
+				잠시 후 다시 접근해주세요.
+			</Text>
+		),
 	}
 
 	return ComponentFactory[type];
 };
 
-const activeButton: {[key in Alert]: string} = {
+const activeButton: {[key in AlertModal]: string} = {
 	'delete': '삭제하기',
 	'cancel': '나가기',
 	'messageRoom': '나가기',
+	'error': '확인',
 };
 
 export default function AlertModal({type, $modalState, handleModal, onConfirm}: Props) {

--- a/src/hooks/component/useModal.tsx
+++ b/src/hooks/component/useModal.tsx
@@ -1,11 +1,11 @@
-import { MouseEventHandler, useState } from "react";
+import { useState } from "react";
 
 import { moveScrollY, stopScrollY } from "@/utils";
 
 export default function useModal() {
 	const [isModalOpen, setIsModalOpen] = useState(false);
 
-	const handleModal: MouseEventHandler<HTMLElement> = () => {
+	const handleModal = () => {
 		if(isModalOpen) {
 			moveScrollY();
 		}

--- a/src/hooks/portfolio/usePortfolioForm.ts
+++ b/src/hooks/portfolio/usePortfolioForm.ts
@@ -2,11 +2,13 @@ import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { useDispatch, useSelector } from "react-redux";
 
-import { setToast, toasts } from "@/redux/toastSlice";
-import { Section } from "@/types";
+import { toasts } from "@/redux/toastSlice";
+
+import type { Section } from "@/types";
+
 import { usePortfolioPostQuery, checkMultipleErrors, addValidationErrorToast } from "@/utils";
 
-export type FormValues = {
+export type PortfolioFormValues = {
 	title: string;
 	content: string;
 	section: Section;
@@ -16,7 +18,7 @@ export type FormValues = {
 	images: string[];
 };
 
-const defaultValues: FormValues = {
+const defaultValues: PortfolioFormValues = {
 	title: '',
 	content: '',
 	section: 'Android/iOS',
@@ -47,12 +49,12 @@ export default function usePortfolioForm({portfolio} : Props) {
 			errors,
 			isSubmitting
 		}
-	} = useForm<FormValues>({
+	} = useForm<PortfolioFormValues>({
 		mode: 'onSubmit',
 		defaultValues: defaultValues,
 	});
 
-	const onSubmit = (form: FormValues) => {
+	const onSubmit = (form: PortfolioFormValues) => {
 		const isEditMode = portfolio ? true: false;
 
 		if(isEditMode) {

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -4,7 +4,7 @@ import { PortfolioHandlers } from "./portfolio";
 import { toggleButtonHandlers } from "./toggleButton";
 import { userHandlers } from "./user";
 
-export const LOGIN_ID = 100;
+export const LOGIN_ID = 'expert1';
 export const AUTHORITY: string = 'client';
 export const PARTNER_ID = AUTHORITY === 'expert' ? 'clientId' : 'expertId';
 export const MY_ID = AUTHORITY + 'Id';

--- a/src/mocks/handlers/portfolio.ts
+++ b/src/mocks/handlers/portfolio.ts
@@ -1,9 +1,9 @@
 import { HttpResponse, http } from 'msw';
 
 import { PortfolioFormValues } from '@/hooks/portfolio/usePortfolioForm';
+import { LOGIN_ID } from '@/mocks/handlers';
 import { portfolios } from '@/mocks/nosql-data/portfolios';
-
-import { users } from '../nosql-data/users';
+import { users } from '@/mocks/nosql-data/users';
 
 import type { Portfolio, Section, Portfolios } from '@/types';
 
@@ -39,7 +39,7 @@ export const PortfolioHandlers= [
 					...portfolios[docKey],
 					id: docKey,
 					isBookmarked: users['client1'].bookmarks[docKey] ? true : false,
-					isLiked: users['client1'].likes[docKey] ? true : false,
+					isLiked: users['client1'].likes.indexOf(docKey) !== -1 ? true : false,
 				};
 
 				filteredPortfolios.push(portfolio);
@@ -123,12 +123,12 @@ export const PortfolioHandlers= [
 		});
 
 		Object.assign(portfolio, {
-			isBookmarked: users['client1'].bookmarks[portfolioId] ? true : false,
-			isLiked: users['client1'].likes[portfolioId] ? true : false,
+			isBookmarked: users[LOGIN_ID].bookmarks[portfolioId] ? true : false,
+			isLiked: users[LOGIN_ID].likes.indexOf(portfolioId) !== -1 ? true : false,
 			otherPortfolios: otherPortfolios,
 		});
 
-		return HttpResponse.json(portfolio, { status: 404 });
+		return HttpResponse.json(portfolio, { status: 200 });
 	}),
 
 	// 포트폴리오 삭제

--- a/src/mocks/handlers/portfolio.ts
+++ b/src/mocks/handlers/portfolio.ts
@@ -3,6 +3,8 @@ import { HttpResponse, http } from 'msw';
 import { PortfolioFormValues } from '@/hooks/portfolio/usePortfolioForm';
 import { portfolios } from '@/mocks/nosql-data/portfolios';
 
+import { users } from '../nosql-data/users';
+
 import type { Portfolio, Section, Portfolios } from '@/types';
 
 import { PAGE_PER_DATA, generateRandomString } from '@/utils';
@@ -38,7 +40,8 @@ export const PortfolioHandlers= [
 				const portfolio: Portfolio = {
 					...portfolios[docKey],
 					id: docKey,
-					isBookmarked: true,
+					isBookmarked: users['client1'].bookmarks[docKey] ? true : false,
+					isLiked: users['client1'].likes[docKey] ? true : false,
 				};
 
 				filteredPortfolios.push(portfolio);

--- a/src/mocks/handlers/portfolio.ts
+++ b/src/mocks/handlers/portfolio.ts
@@ -35,8 +35,6 @@ export const PortfolioHandlers= [
 			const hasUsername = !username && portfolios[docKey].user.name === username;
 
 			if(isSameSection && isSameCategory && isRangeOfPage(index, page)) {
-				// const bookmarks = users.find((user) => user.id === LOGIN_ID)!.bookmarks as number[];
-				// const isBookmarked = getIsBookmarked(portfolio!.id, bookmarks);
 				const portfolio: Portfolio = {
 					...portfolios[docKey],
 					id: docKey,
@@ -104,34 +102,36 @@ export const PortfolioHandlers= [
 		return HttpResponse.json(topPortfolios, { status: 200 });
 	}),
 
+	// 특정 portfolio detail 데이터를 불러온다.
 	http.get('/portfolios/detail', ({request}) => {
 		const url = new URL(request.url);
 		const portfolioId = url.searchParams.get('id') as string;
 
-		// const isBookmarked = getIsBookmarked(portfolio!.id, bookmarks);
-		// const isLiked = getIsLiked(portfolio!.id, likes);
-
 		const portfolio: Portfolio = portfolios[portfolioId];
 
-		const portfolioDocKeys: string[] = Object(portfolios).keys();
-		const otherPortfolios: Portfolios = {};
+		const portfolioDocKeys: string[] = Object.keys(portfolios);
+		const otherPortfolios: Portfolio[] = [];
 
 		portfolioDocKeys.map((docKey: string) => {
 			if(portfolios[docKey].user.id === portfolio.user.id &&
-					Object.keys(otherPortfolios).length < 9){
-				Object.assign(otherPortfolios, portfolios[docKey])
+				otherPortfolios.length < 9){
+					otherPortfolios.push({
+						id: docKey,
+						...portfolios[docKey]
+					});
 			}
 		});
 
 		Object.assign(portfolio, {
-			isBookmarked: true,
-			isLiked: true,
+			isBookmarked: users['client1'].bookmarks[portfolioId] ? true : false,
+			isLiked: users['client1'].likes[portfolioId] ? true : false,
 			otherPortfolios: otherPortfolios,
 		});
 
-		return HttpResponse.json(portfolio, { status: 200 });
+		return HttpResponse.json(portfolio, { status: 404 });
 	}),
 
+	// 포트폴리오 삭제
 	http.delete('/portfolios', ({request}) => {
 		const url = new URL(request.url);
 		const portfolioId = url.searchParams.get('id') as string;
@@ -141,6 +141,7 @@ export const PortfolioHandlers= [
 		return HttpResponse.json(null, { status: 200 });
 	}),
 
+	// 포트폴리오 작성
 	http.post(`/portfolios`, async ({request}) => {
 		const portfolioForm = await request.json() as PortfolioFormValues;
 		const portfolioId = generateRandomString(20);
@@ -164,6 +165,7 @@ export const PortfolioHandlers= [
 		return HttpResponse.json({id: portfolioId}, { status: 200 });
 	}),
 
+	// 포트폴리오 수정
 	http.patch(`/portfolios`, async ({request}) => {
 		const url = new URL(request.url);
 		const portfolioId = url.searchParams.get('id') as string;

--- a/src/mocks/nosql-data/users.ts
+++ b/src/mocks/nosql-data/users.ts
@@ -18,6 +18,8 @@ export const users: Users = {
 			score: 90,
 			contactTime: '언제나 가능',
 		},
+		bookmarks: {},
+		likes: [],
 	},
 	expert2: {
 		name: 'Paul',
@@ -36,6 +38,8 @@ export const users: Users = {
 			score: 100,
 			contactTime: '언제나 가능',
 		},
+		bookmarks: {},
+		likes: [],
 	},
 	expert3: {
 		name: 'George',
@@ -54,6 +58,8 @@ export const users: Users = {
 			score: 100,
 			contactTime: '언제나 가능',
 		},
+		bookmarks: {},
+		likes: [],
 	},
 	expert4: {
 		name: 'Ringo',
@@ -72,6 +78,8 @@ export const users: Users = {
 			score: 100,
 			contactTime: '언제나 가능',
 		},
+		bookmarks: {},
+		likes: [],
 	},
 	expert5: {
 		name: 'Freddie',
@@ -90,6 +98,8 @@ export const users: Users = {
 			score: 100,
 			contactTime: '언제나 가능',
 		},
+		bookmarks: {},
+		likes: [],
 	},
 	client1: {
 		name: '김강철',
@@ -115,18 +125,7 @@ export const users: Users = {
 				thumbnailUrl: '',
 			},
 		},
-		likes: {
-			portfolio1: {
-				title: 'test title',
-				summary: 'test summary',
-				thumbnailUrl: '',
-			},
-			portfolio2: {
-				title: 'test title',
-				summary: 'test summary',
-				thumbnailUrl: '',
-			},
-		},
+		likes: [],
 	},
 	client2: {
 		name: '김우주',
@@ -140,6 +139,8 @@ export const users: Users = {
 			location: '대구',
 			contactTime: '언제나 가능',
 		},
+		bookmarks: {},
+		likes: [],
 	},
 	client3: {
 		name: '스폰지밥',
@@ -153,6 +154,8 @@ export const users: Users = {
 			location: '대구',
 			contactTime: '언제나 가능',
 		},
+		bookmarks: {},
+		likes: [],
 	},
 	client4: {
 		name: '징징이',
@@ -166,6 +169,8 @@ export const users: Users = {
 			location: '대구',
 			contactTime: '언제나 가능',
 		},
+		bookmarks: {},
+		likes: [],
 	},
 	client5: {
 		name: '집게사장',
@@ -179,5 +184,7 @@ export const users: Users = {
 			location: '대구',
 			contactTime: '언제나 가능',
 		},
+		bookmarks: {},
+		likes: [],
 	},
 };

--- a/src/mocks/nosql-data/users.ts
+++ b/src/mocks/nosql-data/users.ts
@@ -1,4 +1,6 @@
-export const users = {
+import { Users } from "@/types";
+
+export const users: Users = {
 	expert1: {
 		name: 'John',
 		email: 'john@example.com',
@@ -89,7 +91,7 @@ export const users = {
 			contactTime: '언제나 가능',
 		},
 	},
-	client6: {
+	client1: {
 		name: '김강철',
 		email: 'steel@example.com',
 		phone: '010-1234-1234',
@@ -101,8 +103,32 @@ export const users = {
 			location: '대구',
 			contactTime: '언제나 가능',
 		},
+		bookmarks: {
+			portfolio1: {
+				title: 'test title',
+				summary: 'test summary',
+				thumbnailUrl: '',
+			},
+			portfolio2: {
+				title: 'test title',
+				summary: 'test summary',
+				thumbnailUrl: '',
+			},
+		},
+		likes: {
+			portfolio1: {
+				title: 'test title',
+				summary: 'test summary',
+				thumbnailUrl: '',
+			},
+			portfolio2: {
+				title: 'test title',
+				summary: 'test summary',
+				thumbnailUrl: '',
+			},
+		},
 	},
-	client7: {
+	client2: {
 		name: '김우주',
 		email: 'universe@example.com',
 		phone: '010-1234-1234',
@@ -115,7 +141,7 @@ export const users = {
 			contactTime: '언제나 가능',
 		},
 	},
-	client8: {
+	client3: {
 		name: '스폰지밥',
 		email: 'underthesea@example.com',
 		phone: '010-1234-1234',
@@ -128,7 +154,7 @@ export const users = {
 			contactTime: '언제나 가능',
 		},
 	},
-	client9: {
+	client4: {
 		name: '징징이',
 		email: 'squeed@example.com',
 		phone: '010-1234-1234',
@@ -141,7 +167,7 @@ export const users = {
 			contactTime: '언제나 가능',
 		},
 	},
-	client10: {
+	client5: {
 		name: '집게사장',
 		email: 'crab@example.com',
 		phone: '010-1234-1234',

--- a/src/pages/portfolio-detail/PortfolioDetailPage.styled.tsx
+++ b/src/pages/portfolio-detail/PortfolioDetailPage.styled.tsx
@@ -65,7 +65,7 @@ export const TitleBox = styled(FlexColumnBox)`
 	border: 1rem;
 	margin-top: 1rem;
 
-	& span {
+	& > span {
 		font-weight: 600;
 	}
 `;

--- a/src/pages/portfolio-detail/PortfolioDetailPage.styled.tsx
+++ b/src/pages/portfolio-detail/PortfolioDetailPage.styled.tsx
@@ -23,12 +23,12 @@ export const Content = styled.main`
 `;
 
 export const PortfolioSection = styled.section`
-	${mixins.fullWidthHeight}
-
+	width: 100%;
+	height: inherit;
 	flex-basis: 1;
 	padding: 2.5rem 1rem;
-
-	border-top: 2px solid #f5f5f5;
+	border-radius: 1rem;
+	background-color: #f3f3f3;
 `;
 
 export const HtmlContent = styled.div`
@@ -47,7 +47,6 @@ export const Aside = styled.aside`
 
 export const FlexColumnBox = styled.div`
 	${mixins.flexColumn}
-	padding: 2.4rem 0.5rem 2rem 0.5rem;
 	border-radius: 1.5rem;
 	gap: 1rem;
 `;
@@ -56,20 +55,25 @@ export const ProfileBox = styled(FlexColumnBox)`
 	${mixins.flexCenter}
 	gap: 1.8rem;
 	border: 1px solid #efefef;
-`;
-
-export const InformationBox = styled(FlexColumnBox)`
-	${mixins.flexColumn}
-	gap: 1.5rem;
+	padding: 2.4rem 0.5rem 2rem 0.5rem;
 `;
 
 export const TitleBox = styled(FlexColumnBox)`
-	padding: 0;
+	padding: 1rem;
 	gap: 0.5rem;
+	background-color: #f3f3f3;
+	border: 1rem;
+	margin-top: 1rem;
 
 	& span {
 		font-weight: 600;
 	}
+`;
+
+export const InformationBox = styled(FlexColumnBox)`
+	${mixins.flexColumn}
+	padding: 2.4rem 0.5rem 2rem 0.5rem;
+	gap: 1.5rem;
 `;
 
 export const ButtonGroup = styled.div`
@@ -105,6 +109,7 @@ export const GridItem = styled.div`
 
 	border-radius: 0.6rem;
 	cursor: pointer;
+	background-color: #f3f3f3;
 
 	& img {
 		width: 100%;

--- a/src/pages/portfolio-detail/PortfolioDetailPage.tsx
+++ b/src/pages/portfolio-detail/PortfolioDetailPage.tsx
@@ -3,15 +3,12 @@ import { FiChevronRight as ChevronRightIcon , FiArrowLeft as LeftArrowIcon } fro
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { setAlert } from "@/redux/alertSlice";
-import { userState } from "@/redux/loginSlice";
-import { section } from "@/redux/sectionSlice";
-
-import * as S from "./PortfolioDetailPage.styled";
+import * as S from "@/pages/portfolio-detail/PortfolioDetailPage.styled";
 
 import type { Portfolio } from "@/types";
 
 import { useHtmlContent } from "@/hooks";
+import { setAlert, userState, section } from "@/redux";
 import { usePortfolioDeleteQuery, usePortfolioDetailQuery, toUrlParameter } from "@/utils";
 
 import { Text, Image, Button, ToggleButton, Tag, Profile } from "@/components";

--- a/src/pages/portfolio-detail/PortfolioDetailPage.tsx
+++ b/src/pages/portfolio-detail/PortfolioDetailPage.tsx
@@ -95,23 +95,33 @@ export default function PortfolioDetail(){
 						<S.ButtonGroup>
 							<ToggleButton
 								type='like'
-								portfolioId={portfolio?.id}
+								portfolioId={portfolioId}
 								isToggled={portfolio?.isLiked}
 								currentLikes={portfolio?.likes}
 							/>
 							<ToggleButton
 								type='bookmark'
-								portfolioId={portfolio?.id}
+								portfolioId={portfolioId}
 								isToggled={portfolio?.isBookmarked}
 							/>
 						</S.ButtonGroup>
 
 						{ user?.id === portfolio?.user?.id &&
 							<S.ButtonGroup>
-								<Text size='bodyMedium' color='lightgray' onClick={handleEditButton} cursor>
+								<Text
+									size='bodyMedium'
+									color='lightgray'
+									onClick={handleEditButton}
+									cursor
+								>
 									수정하기
 								</Text>
-								<Text size='bodyMedium' color='lightgray' onClick={handleDeleteButton} cursor>
+								<Text
+									size='bodyMedium'
+									color='lightgray'
+									onClick={handleDeleteButton}
+									cursor
+								>
 									삭제하기
 								</Text>
 							</S.ButtonGroup>

--- a/src/redux/alertSlice.ts
+++ b/src/redux/alertSlice.ts
@@ -1,0 +1,33 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import { RootState } from '@/redux/store';
+
+import type { AlertModal } from '@/types';
+
+type InitialState = {
+	modal: {
+		type: AlertModal,
+		onConfirm: () => void,
+	} | null;
+}
+
+const initialState: InitialState = {
+	modal: null,
+};
+
+export const alertSlice = createSlice({
+  name: 'alert',
+  initialState,
+  reducers: {
+    setModal: (state, action) => {
+			state.modal = action.payload;
+		},
+    deleteModal: (state) => {
+			state.modal = null;
+		},
+  },
+});
+
+export const { setModal, deleteModal } = alertSlice.actions;
+export const alertState = (state: RootState) => state.alert.modal;
+export default alertSlice;

--- a/src/redux/alertSlice.ts
+++ b/src/redux/alertSlice.ts
@@ -19,15 +19,15 @@ export const alertSlice = createSlice({
   name: 'alert',
   initialState,
   reducers: {
-    setModal: (state, action) => {
+    setAlert: (state, action) => {
 			state.modal = action.payload;
 		},
-    deleteModal: (state) => {
+    deleteAlert: (state) => {
 			state.modal = null;
 		},
   },
 });
 
-export const { setModal, deleteModal } = alertSlice.actions;
+export const { setAlert, deleteAlert } = alertSlice.actions;
 export const alertState = (state: RootState) => state.alert.modal;
 export default alertSlice;

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -1,0 +1,4 @@
+export * from '@/redux/alertSlice';
+export * from '@/redux/loginSlice';
+export * from '@/redux/sectionSlice';
+export * from '@/redux/toastSlice';

--- a/src/redux/loginSlice.ts
+++ b/src/redux/loginSlice.ts
@@ -3,7 +3,7 @@ import { createSlice } from '@reduxjs/toolkit';
 import { RootState } from './store';
 
 type InitialState = {
-	id: number | null;
+	id: string | null;
 	isLogin: boolean;
 	authority: 'expert' | 'client' | null;
 	profileImage: string | null,
@@ -23,7 +23,7 @@ export const loginSlice = createSlice({
 		login: (state, action) => {
 			state.authority = action.payload;
 			state.isLogin = true;
-			state.id = action.payload === 'expert' ? 1 : 100;
+			state.id = action.payload === 'expert' ? 'expert1' : 'client1';
 			state.profileImage = 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FL1CyJ%2FbtsEliBIlFI%2FyxkummQTr4hNMBMceXTSJ0%2Fimg.png';
 		},
 		logout: (state) => {

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -2,6 +2,7 @@ import { combineReducers, configureStore, getDefaultMiddleware } from '@reduxjs/
 import { persistReducer } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 
+import alertSlice from '@/redux/alertSlice';
 import loginSlice from '@/redux/loginSlice';
 import sectionSlice from '@/redux/sectionSlice';
 import toastSlice from '@/redux/toastSlice';
@@ -22,6 +23,7 @@ const rootReducer = combineReducers({
 	user: persistReducer(authPersistConfig, loginSlice.reducer),
 	section: persistReducer(sectionPersistConfig, sectionSlice.reducer),
 	toast: toastSlice.reducer,
+	alert: alertSlice.reducer,
 });
 
 export const store = configureStore({

--- a/src/redux/toastSlice.ts
+++ b/src/redux/toastSlice.ts
@@ -1,8 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { RootState } from './store';
+import { RootState } from '@/redux/store';
 
-import { Toast } from '@/types';
+import type { Toast } from '@/types';
 
 type InitialState = {
 	toasts: Toast[],

--- a/src/types/api-data/commission.ts
+++ b/src/types/api-data/commission.ts
@@ -1,3 +1,7 @@
+export type Commissions = {
+	[key in string]: Commission;
+}
+
 export type Commission = {
 	client: {
 		name: string,
@@ -6,9 +10,9 @@ export type Commission = {
 		nickname: string,
 		profileImage: string,
 	},
-	review: Review,
+	review: Review | null,
 	createdAt: Date,
-	endedAt: Date,
+	endedAt: Date | null,
 	details: CommissionDetail,
 };
 

--- a/src/types/api-data/user.ts
+++ b/src/types/api-data/user.ts
@@ -1,5 +1,3 @@
-import type { Portfolio, Portfolios } from "@/types";
-
 export type Authority = 'expert' | 'client';
 
 export type Users = {
@@ -14,8 +12,8 @@ export type User = {
 	profileImage: string,
 	authority: Authority,
 	profile: UserProfile,
-	bookmarks?: any,
-	likes?: any,
+	bookmarks: any,
+	likes: string[],
 };
 
 export type UserProfile = {

--- a/src/types/api-data/user.ts
+++ b/src/types/api-data/user.ts
@@ -1,4 +1,6 @@
-export type Authority = 'export' | 'client';
+import type { Portfolio, Portfolios } from "@/types";
+
+export type Authority = 'expert' | 'client';
 
 export type Users = {
 	[key in string] : User;
@@ -12,6 +14,8 @@ export type User = {
 	profileImage: string,
 	authority: Authority,
 	profile: UserProfile,
+	bookmarks?: any,
+	likes?: any,
 };
 
 export type UserProfile = {
@@ -22,5 +26,5 @@ export type UserProfile = {
 	fields?: string[],
 	stacks?: string[],
 	score?: number,
-	contactTime: string[],
+	contactTime: string,
 };

--- a/src/types/global-component.ts
+++ b/src/types/global-component.ts
@@ -1,0 +1,9 @@
+export type Toast = {
+	id: string,
+	type: 'error' | 'success',
+	message: string,
+};
+
+export type Modal = 'alert' | 'search' | 'commission';
+
+export type AlertModal = 'delete' | 'cancel' | 'messageRoom' | 'error';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,7 +13,7 @@ export type SetState<T> = React.Dispatch<React.SetStateAction<T>>;
 // export * from '@/types/portfolio';
 // export * from '@/types/user';
 export * from '@/types/slider';
-export * from '@/types/toast';
+export * from '@/types/global-component';
 // export * from '@/types/commission';
 export * from '@/types/style';
 

--- a/src/types/toast.ts
+++ b/src/types/toast.ts
@@ -1,5 +1,0 @@
-export type Toast = {
-	id: string,
-	type: 'error' | 'success',
-	message: string,
-};

--- a/src/utils/api-service/portfolio.ts
+++ b/src/utils/api-service/portfolio.ts
@@ -61,6 +61,7 @@ export const usePortfolioDetailQuery = (id: string) => {
 		queryFn: getPortfolio,
 		staleTime: Infinity,
 		gcTime: Infinity,
+		throwOnError: false,
 	});
 };
 

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,7 +1,8 @@
 import axios, { AxiosHeaders } from 'axios';
-import type { AxiosRequestHeaders, AxiosRequestConfig } from 'axios';
 
 import { API_BASE_URL } from '@/app-config';
+
+import type { AxiosRequestHeaders, AxiosRequestConfig } from 'axios';
 
 type Method = 'GET' | 'POST' | 'PATCH' | 'DELETE';
 


### PR DESCRIPTION
## 개요
PortfolioDetail.tsx 페이지 Api 에러 처리를 추가합니다.

## 작업사항
* `/mocks/nosql-data/user.ts` 더미 데이터에 bookmarks, likes를 추가한다.
* `PortfolioDetail.tsx` 페이지 api 반환값이 `undefined`여도 템플릿 형태가 보이도록 한다.
* `PortfolioDetail.tsx` 페이지 api 에러 발생 시 `AlertModal.tsx`을 띄운다.
  * 확인 버튼 클릭 시 이전 페이지로 돌아간다.
* `AlertModla.tsx`의 경우 한 페이지에서 여러가지 형태로 호출되므로 글로벌 컴포넌트로 관리한다.
  * `AlertContainer.tsx` 컴포넌트를 생성해 `App.tsx`에서 호출한다.
  * `alertSlice` 전역 상태를 생성한다.
  * alert를 띄워야 하는 페이지에서 `dispatch(setAlert())`를 하면 저장된 alert 정보를 기반으로 전역에서` AlertModal.tsx`를 띄운다.
  * `type`(alert 종류), `onConfirm` 콜백 함수를 props로 전달한다.

## 변경로직
* AlertModal.tsx는 alertSlice를 활용해 AlertContainer.tsx전역 컴포넌트로 띄운다.

### 변경전
* `AlertModal.tsx`를 띄우는 페이지에서 `isModalOpen` state로 조건부 렌더링

### 변경후

https://github.com/Kim-DaHam/Portfolly/assets/81691456/eead09f8-23f2-4a25-97d4-61c22afda194

