### PR TITLE
Feat: /portfolio DELETE 요청에 대한 결과를 toast로 알린다

### DIFF
--- a/src/pages/portfolio-detail/PortfolioDetailPage.tsx
+++ b/src/pages/portfolio-detail/PortfolioDetailPage.tsx
@@ -19,7 +19,6 @@ export default function PortfolioDetail(){
 
 	const user = useSelector(userState);
 	const portfolioId = useParams().portfolio_id as string;
-	const currentSection = useSelector(section);
 
 	const { sanitize, setElementInlineStyle } = useHtmlContent();
 	const { data: portfolio, isError } = usePortfolioDetailQuery(portfolioId);
@@ -39,7 +38,6 @@ export default function PortfolioDetail(){
 
 	const deletePortfolio = async () => {
 		await deletePorfolioMutation.mutate();
-		navigate(`/main/${toUrlParameter(currentSection)}`);
 	};
 
 	useEffect(() => {

--- a/src/utils/api-service/portfolio.ts
+++ b/src/utils/api-service/portfolio.ts
@@ -1,13 +1,13 @@
 import { useMutation, useQuery, useQueryClient, useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import axios from 'axios';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
 import { Toggle } from '@/components/atoms/button/ToggleButton';
 
 import type { Section } from '@/types';
 
-import { setToast } from '@/redux';
+import { section, setToast } from '@/redux';
 import { fetch, toUrlParameter } from "@/utils";
 
 export const PAGE_PER_DATA = 10;
@@ -73,6 +73,10 @@ export const usePortfolioDetailQuery = (id: string) => {
 
 // 포트폴리오 삭제
 export const usePortfolioDeleteQuery = (id: string) => {
+	const navigate = useNavigate();
+	const dispatch = useDispatch();
+	const currentSection = useSelector(section);
+
 	const queryClient = useQueryClient();
 	const deletePortfolio = () => fetch(`/portfolios?id=${id}`, 'DELETE');
 
@@ -80,7 +84,11 @@ export const usePortfolioDeleteQuery = (id: string) => {
 		mutationFn: deletePortfolio,
 		onSuccess: () => {
 			queryClient.removeQueries({queryKey: ['portfolios', 'detail', id]})
-			queryClient.invalidateQueries({queryKey: ['portfolios'], refetchType: 'all' });
+			dispatch(setToast({id: 0, type:'success', message: '포트폴리오를 삭제했습니다.'}));
+			navigate(`/main/${toUrlParameter(currentSection)}`);
+		},
+		onError: () => {
+			dispatch(setToast({id: 0, type:'error', message: '삭제를 실패했습니다.'}));
 		},
 	});
 };


### PR DESCRIPTION
## 개요
PortfolioDetail.tsx 페이지 '삭제하기' 버튼 클릭 시 DELETE 요청에 대한 에러 처리를 추가합니다.

## 작업사항
* DELETE 요청 정상 작동 시 '포트폴리오가 삭제되었습니다.' toast가 나타나고, 메인 페이지로 이동한다.
* DELETE 요청 실패 시 '삭제를 실패했습니다.' toast가 나타나고, 페이지는 그대로 유지된다.

### 변경후

https://github.com/Kim-DaHam/Portfolly/assets/81691456/ce7d276f-6984-4c18-ac12-d04f030ff3b3

## 기타
이전에 메인 페이지에 방문한 기록이 있어 그에 대한 query가 캐시에 저장되어 있다면, 그 목록에서 당장 포트폴리오가 삭제되진 않습니다.

사용자가 어떤 경로로 메인 페이지에 접근하느냐에 따라 queryKey가 상이해서(filter.appCategory 등), 특정 queryKey의 상태를 업데이트 하기엔 어려움이 있습니다.

또한 portfolios 라는 queryKey를 가진 query를 전부 invalidate 해서 데이터를 전부 새로 불러오기에도, 당장 포트폴리오 목록 상단에 사용자가 삭제한 포트폴리오가 없을 가능성을 따질 경우 불필요한 패칭이라고 생각했습니다.

만약 상단에 사용자의 포트폴리오가 있더라도, 다시 클릭했을 때 페이지를 불러올 수 없다는 AlertModal이 나타나기 때문에 삭제된 데이터에 다시 접근할 가능성은 없습니다.