### PR TITLE
Feat: /portfolio/edit PATCH 요청 핸들러 수정 및 에러 처리를 추가한다

### DIFF
--- a/src/components/atoms/image/Image.styled.tsx
+++ b/src/components/atoms/image/Image.styled.tsx
@@ -9,7 +9,6 @@ export const ImageLayout = styled.div<Props>`
 
 	flex: none;
 	overflow: hidden;
-	background-color: #f3f3f3;
 
 	${(props) => {
 		if(props.shape === 'circle'){

--- a/src/mocks/handlers/portfolio.ts
+++ b/src/mocks/handlers/portfolio.ts
@@ -162,7 +162,12 @@ export const PortfolioHandlers= [
 			commissions: null,
 		};
 
-		return HttpResponse.json({id: portfolioId}, { status: 200 });
+		const response = {
+			id: portfolioId,
+			...portfolios[portfolioId]
+		};
+
+		return HttpResponse.json(response, { status: 200 });
 	}),
 
 	// 포트폴리오 수정
@@ -173,9 +178,15 @@ export const PortfolioHandlers= [
 
 		Object.assign(portfolios[portfolioId], portfolioForm);
 
-		return HttpResponse.json({id: portfolioId}, { status: 200 });
+		const response = {
+			id: portfolioId,
+			...portfolios[portfolioId]
+		};
+
+		return HttpResponse.json(response, { status: 200 });
 	}),
 
+	// 이미지 등록
 	http.post(`/picture`, async () => {
 		const imageUrl = [
 			'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2F2XzQc%2FbtsCoF6oqiQ%2FfTLqaY7HBAdFUn22D1UVP0%2Fimg.jpg',

--- a/src/mocks/handlers/portfolio.ts
+++ b/src/mocks/handlers/portfolio.ts
@@ -154,6 +154,19 @@ export const PortfolioHandlers= [
 			profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 		};
 
+		const portfolioDocKeys: string[] = Object.keys(portfolios);
+		const otherPortfolios: Portfolio[] = [];
+
+		portfolioDocKeys.map((docKey: string) => {
+			if(portfolios[docKey].user.id === user.id &&
+				otherPortfolios.length < 9){
+					otherPortfolios.push({
+						id: docKey,
+						...portfolios[docKey]
+					});
+			}
+		});
+
 		portfolios[portfolioId] = {
 			user: user,
 			createdAt: new Date(Date.now()),
@@ -164,7 +177,8 @@ export const PortfolioHandlers= [
 
 		const response = {
 			id: portfolioId,
-			...portfolios[portfolioId]
+			...portfolios[portfolioId],
+			otherPortfolios: otherPortfolios,
 		};
 
 		return HttpResponse.json(response, { status: 200 });

--- a/src/pages/portfolio-edit/PortfolioEditPage.styled.tsx
+++ b/src/pages/portfolio-edit/PortfolioEditPage.styled.tsx
@@ -76,6 +76,7 @@ export const TitleInput = styled.input`
 	height: 4rem;
 	border: 0;
 	font-size: 1.5rem;
+	font-weight: 600;
 	&:focus {
 		outline: none;
 	}

--- a/src/pages/portfolio-edit/PortfolioEditPage.tsx
+++ b/src/pages/portfolio-edit/PortfolioEditPage.tsx
@@ -87,7 +87,14 @@ export default function PortfolioEditPage(){
 						})}>
 							<S.TagInput contentEditable onKeyUp={handleTagInput}/>
 							{tags.map((tag: string, index: number) => {
-								return <Tag readOnly={false} value={tag} key={index} handleTag={handleTag}/>
+								return (
+									<Tag
+										readOnly={false}
+										value={tag}
+										key={index}
+										handleTag={handleTag}
+									/>
+								)
 							})}
 						</S.TagBox>
 					</S.Box>
@@ -103,7 +110,13 @@ export default function PortfolioEditPage(){
 						/>
 					</S.Box>
 
-					<Button color='black' size='medium' shape='square' type='submit'>작성하기</Button>
+					<Button
+						color='black'
+						size='medium'
+						type='submit'
+					>
+						작성하기
+					</Button>
 				</S.Form>
 			</S.FormSection>
 		</S.Wrapper>

--- a/src/utils/api-service/portfolio.ts
+++ b/src/utils/api-service/portfolio.ts
@@ -160,21 +160,33 @@ export const useToggleButtonQuery = (id: string, type: Toggle) => {
 	})
 };
 
+// 포트폴리오 작성/수정
 export const usePortfolioPostQuery = (id?: string) => {
 	const queryClient = useQueryClient();
+	const queryKey = ['portfolios', 'detail', id];
 	const postPortfolio = (body: any) => fetch(`/portfolios`, 'POST', body);
 	const updatePortfolio = (body: any) => fetch(`/portfolios?id=${id}`, 'PATCH', body);
 
 	const navigate = useNavigate();
+	const dispatch = useDispatch();
 
 	return useMutation({
 		mutationFn: id? updatePortfolio : postPortfolio,
-		onSuccess: (data) => {
+		onSuccess: (response) => {
 			if(id) {
-				queryClient.removeQueries({queryKey: ['portfolios', 'detail', id]});
+				queryClient.setQueryData(queryKey, () => {
+					return response;
+				});
 			}
-			queryClient.invalidateQueries({queryKey: ['portfolios'], refetchType: 'all' });
-			navigate(`/portfolios/${data.id}`);
+			queryClient.setQueryData(['portfolios', 'detail', response.id], () => {
+				return response;
+			});
+			// queryClient.invalidateQueries({queryKey: ['portfolios'], refetchType: 'all' });
+			navigate(`/portfolios/${response.id}`);
+			dispatch(setToast({id: 0, type:'success', message: '포트폴리오가 등록되었습니다.'}));
+		},
+		onError: () => {
+			dispatch(setToast({id: 0, type:'success', message: '포트폴리오 등록에 실패했습니다.'}));
 		},
 	});
 };


### PR DESCRIPTION
## 개요
PortfolioEdit.tsx 페이지 /portfolio/edit 요청에 대한 핸들러를 수정하고 api 요청에 대한 에러 처리를 추가합니다.

## 작업사항
* `/portfolio/edit` POST, PATCH 요청에 실패할 경우 에러 Toast를 띄운다.
  * 성공할 경우 성공 Toast를 띄우고 해당 게시물 페이지로 navigate한다.

## 변경로직
* 포트폴리오 등록/수정 후 'portfolios' 키워드를 가진 queryKey 캐시를 refetch하는 로직을 삭제했습니다.

### 변경후

https://github.com/Kim-DaHam/Portfolly/assets/81691456/4b79ae94-d09c-486a-be0d-fd5d7989c2d9

