### PR TITLE
Fix: /reviews POST 요청 핸들러를 수정한다.

### DIFF
--- a/src/components/molecules/items/commission-item/CommissionItem.tsx
+++ b/src/components/molecules/items/commission-item/CommissionItem.tsx
@@ -1,11 +1,11 @@
-import React, { HTMLAttributes, useEffect, useState } from 'react';
+import React, { HTMLAttributes, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import * as S from '@/components/molecules/items/commission-item/CommissionItem.styled';
 
 import { useModal } from '@/hooks';
 import { userState } from '@/redux';
-import { eventStopPropagation, toLocalDateString } from '@/utils';
+import { eventStopPropagation } from '@/utils';
 
 import { Button, CommissionModal, ReviewForm, ReviewItem, Text } from '@/components';
 

--- a/src/components/molecules/items/commission-item/CommissionItem.tsx
+++ b/src/components/molecules/items/commission-item/CommissionItem.tsx
@@ -55,7 +55,10 @@ export default function CommissionItem({ commission, index }: Props) {
 					</Button>
 				}
 
-				{ !isReviewOpen && authority === 'client' && !commission.review &&
+				{ !isReviewOpen &&
+					authority === 'client' &&
+					!commission.review &&
+					commission.details.status === '구매 확정' &&
 					<Button
 						color='gray'
 						onClick={handleReviewButton}
@@ -77,7 +80,9 @@ export default function CommissionItem({ commission, index }: Props) {
 				</S.ReviewBox>
 			}
 
-			{ isReviewOpen && authority === 'client' && !commission.review &&
+			{ isReviewOpen &&
+				authority === 'client' &&
+				!commission.review &&
 				<ReviewForm
 					handleReviewOpen={setIsReviewOpen}
 					commission={commission}

--- a/src/components/molecules/items/commission-item/CommissionItem.tsx
+++ b/src/components/molecules/items/commission-item/CommissionItem.tsx
@@ -35,7 +35,11 @@ export default function CommissionItem({ commission, index }: Props) {
 						{commission.details.title}
 					</Text>
 					<Text size='bodySmall'>
-						{commission.client.nickname}
+						{authority === 'expert' ?
+							commission.client.nickname
+							:
+							commission.expert.nickname
+						}
 					</Text>
 					<Text size='bodySmall'>
 						{commission.createdAt}

--- a/src/components/molecules/rating/Rating.tsx
+++ b/src/components/molecules/rating/Rating.tsx
@@ -13,10 +13,10 @@ type Props = {
 };
 
 function Rating({ readonly=false, setValue=()=>'', score=0 }: Props) {
-	const [rating, setRating] = useState(score/20);
+	const [rating, setRating] = useState(score / 20);
 
 	const handleRating = (value: number) => {
-		setValue('rating', value*20);
+		setValue('score', value * 20);
 		setRating(value);
 	};
 

--- a/src/components/molecules/review-form/ReviewForm.tsx
+++ b/src/components/molecules/review-form/ReviewForm.tsx
@@ -3,7 +3,6 @@ import { useForm } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
 
 import * as S from '@/components/molecules/review-form/ReviewForm.styled';
-import { setToast } from '@/redux/toastSlice';
 import { SetState } from "@/types";
 import { useReviewPostQuery } from '@/utils/api-service/commission';
 
@@ -18,12 +17,12 @@ type Props = {
 
 export type FormValues = {
 	content: string;
-	rating: number;
+	score: number;
 };
 
 const defaultValues: FormValues = {
 	content: '',
-	rating: 0,
+	score: 0,
 };
 
 export default function ReviewForm({ handleReviewOpen, commission }: Props) {
@@ -33,13 +32,12 @@ export default function ReviewForm({ handleReviewOpen, commission }: Props) {
 		defaultValues: defaultValues,
 	});
 
-	const reviewMutation = useReviewPostQuery(commission.id);
+	const reviewMutation = useReviewPostQuery(commission.id, commission.portfolio.id);
 
 	const onSubmit = (form: FormValues) => {
 		return reviewMutation.mutate(form, {
 			onSuccess: () => {
 				handleReviewOpen(false);
-				dispatch(setToast({ id: 0, type: 'success', message: '리뷰가 등록되었습니다.'}));
 			},
 		});
 	};
@@ -48,23 +46,36 @@ export default function ReviewForm({ handleReviewOpen, commission }: Props) {
 		addValidationErrorToast(isSubmitting, errors, dispatch);
 	}, [isSubmitting]);
 
-	console.log(commission.portfolio)
-
 	return (
 		<S.Wrapper>
 			<Profile type='portfolio' portfolio={commission.portfolio}/>
 			<S.Form onSubmit={handleSubmit(onSubmit)}>
-				<Rating setValue={setValue} {...register('rating', {
-					validate: (value: number) => value === 0 ? '별점을 등록하세요.' : true,
-				})}/>
-				<S.TextArea {...register('content', {
-					required: '리뷰를 최소 10글자 이상 작성하세요.',
-					validate: (value: string) => value.length < 10 ? '리뷰를 최소 10글자 이상 작성하세요.' : true,
-				})}/>
+				<Rating
+					setValue={setValue}
+					{...register('score', {
+						validate: (value: number) => value === 0 ? '별점을 등록하세요.' : true,
+					})}
+				/>
+				<S.TextArea
+					{...register('content', {
+						required: '리뷰를 최소 10글자 이상 작성하세요.',
+						validate: (value: string) => value.length < 10 ? '리뷰를 최소 10글자 이상 작성하세요.' : true,
+					})}
+				/>
 
 				<S.ButtonBox>
-					<Button color='black' type='submit'>리뷰 등록</Button>
-					<Button color='gray' onClick={() => handleReviewOpen(false)}>작성 취소</Button>
+					<Button
+						color='black'
+						type='submit'
+					>
+						리뷰 등록
+					</Button>
+					<Button
+						color='gray'
+						onClick={() => handleReviewOpen(false)}
+					>
+						작성 취소
+					</Button>
 				</S.ButtonBox>
 			</S.Form>
 		</S.Wrapper>

--- a/src/components/organisms/modal/commission-modal/CommissionModal.tsx
+++ b/src/components/organisms/modal/commission-modal/CommissionModal.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { FiX as XIcon } from "react-icons/fi";
 import { useDispatch, useSelector } from "react-redux";

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -4,7 +4,7 @@ import { PortfolioHandlers } from "./portfolio";
 import { toggleButtonHandlers } from "./toggleButton";
 import { userHandlers } from "./user";
 
-export const LOGIN_ID = 'expert1';
+export const LOGIN_ID = 'client1';
 export const AUTHORITY: string = 'client';
 export const PARTNER_ID = AUTHORITY === 'expert' ? 'clientId' : 'expertId';
 export const MY_ID = AUTHORITY + 'Id';

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -40,8 +40,6 @@ export default function MyPage(){
 		setPrevUrl(route);
 	}, []);
 
-	console.log(user)
-
 	return(
 		<S.Wrapper>
 			<LeftArrowIcon

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -10,11 +10,11 @@ import { usePageErrorAlert } from "@/hooks";
 import { userState } from "@/redux";
 import { useUserQuery } from "@/utils";
 
-import { ActivityInformation, MyPageNavigator, Profile, ProfileSkeleton } from "@/components";
+import { ActivityInformation, MyPageNavigator, Profile } from "@/components";
 
 export type Navigation = 'introduce' | 'portfolios' | 'review' | 'management' | 'bookmarks';
 
-function MyPage(){
+export default function MyPage(){
 	const [navigation , setNavigation] = useState<Navigation>('introduce');
 	const [prevUrl, setPrevUrl] = useState<string | null>(null);
 
@@ -71,5 +71,3 @@ function MyPage(){
 		</S.Wrapper>
 	)
 }
-
-export default MyPage;

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -40,6 +40,8 @@ export default function MyPage(){
 		setPrevUrl(route);
 	}, []);
 
+	console.log(user)
+
 	return(
 		<S.Wrapper>
 			<LeftArrowIcon

--- a/src/utils/api-service/commission.ts
+++ b/src/utils/api-service/commission.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useSelector } from "react-redux";
 
 import { userState } from "@/redux/loginSlice";
-import { Commission, Portfolio, User } from "@/types";
+import { Commission, Portfolio } from "@/types";
 
 import { fetch } from '@/utils'
 

--- a/src/utils/api-service/commission.ts
+++ b/src/utils/api-service/commission.ts
@@ -1,13 +1,15 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import { userState } from "@/redux/loginSlice";
-import { Commission, Portfolio } from "@/types";
+import { Commission, Portfolio, Review, User } from "@/types";
 
+import { setToast } from "@/redux";
 import { fetch } from '@/utils'
 
 // 커미션 폼 작성
 export const usePostCommissionQuery = (portfolioId: string, clientId?: string, commissionId?: string) => {
+	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
 	const postUrl = `/commissions?portfolio_id=${portfolioId}&client_id=${clientId}`;
 	const patchUrl = `/commissions?commission_id=${commissionId}&portfolio_id=${portfolioId}`;
@@ -44,6 +46,7 @@ export const usePostCommissionQuery = (portfolioId: string, clientId?: string, c
 					commissionList: commissionList,
 					portfolioList: portfolioList,
 				});
+
 				return;
 			}
 
@@ -53,29 +56,52 @@ export const usePostCommissionQuery = (portfolioId: string, clientId?: string, c
 				return message;
 			});
 
+			dispatch(setToast({id: 0, type: 'success', message: '커미션이 수정되었습니다.'}));
 			return response;
+		},
+		onError: () => {
+			dispatch(setToast({id: 0, type: 'error', message: '수정을 실패했습니다.'}));
+			return;
 		},
 	});
 };
 
-export const useReviewPostQuery = (id: number) => {
+// 리뷰 작성
+export const useReviewPostQuery = (commissionId: string, portfolioId: string) => {
+	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
 	const { id: userId } = useSelector(userState);
 	const user = queryClient.getQueryData(['user', `${userId}`]) as any;
+	const commissionList = JSON.parse(JSON.stringify(user.commissionList));
 
-	const postReview = (body: any) => fetch(`/reviews?id=${id}`, 'POST', body)
+	const postReview = (body: any) => fetch(`/reviews?
+		commission_id=${commissionId}&
+		portfolio_id=${portfolioId}`,
+		'POST',
+		body
+	)
 
 	return useMutation({
 		mutationFn: postReview,
-		onSuccess: (response: any) => {
-			queryClient.setQueryData(['user', `${userId}`], () => {
-				const commission = user.activity.commissions.find((commission: any) => {
-					return commission.id === id;
-				});
+		onSuccess: (response: Review) => {
+			commissionList.forEach((commission: Commission, index: number) => {
+				if(commission.id !== commissionId) return;
+				commissionList[index].review = response;
+				return false;
+			})
 
-				commission.review = response;
+			queryClient.setQueryData(['user', `${userId}`], {
+				...user,
+				commissionList: commissionList,
 			});
+
+			dispatch(setToast({id: 0, type: 'success', message: '리뷰를 등록했습니다.'}));
+
 			return;
-		}
+		},
+		onError: () => {
+			dispatch(setToast({id: 0, type: 'error', message: '리뷰 등록에 실패했습니다.'}));
+			return;
+		},
 	})
 };


### PR DESCRIPTION
## 개요
`MyPage.tsx` 페이지의 management 탭에서 클라이언트의 리뷰 작성을 수행하는 `/reviews` POST 요청 핸들러를 수정합니다.

NoSQL 데이터 형식에 맞춰 핸들러를 수정했습니다.

## 작업사항
* `/mocks/handlers/commission.ts`에서 리뷰 등록 핸들러를 수정한다.
* 리뷰 등록을 성공할 경우 `setQueryData`로 클라이언트 데이터를 업데이트 한다.
* api 요청 실패/성공 여부를 Toast로 사용자에게 보여준다.
* `CommissionItem.tsx` 컴포넌트 이름 부분을 수정한다.
  * 클라이언트 계정인 경우 전문가 이름을 출력한다.
  * 전문가 계정인 경우 클라이언트 이름을 출력한다.

### 변경후

https://github.com/Kim-DaHam/Portfolly/assets/81691456/55116ef8-27a2-4f28-b71c-6a551979f2b2


## 기타 사항
기존 방식은 commission 데이터를 portfolio 컬렉션 안에 commissions 중첩 컬렉션으로 저장해 관리합니다.

전문가 계정의 경우 자신의 portfolio를 순회하면서 commissionList를 만듭니다.

하지만 클라이언트의 경우 본인의 portfolio가 없기 때문에 자신의 commissionList를 만들기 위해서는
존재하는 모든 portfolio의 commission을 순회해야 합니다.

user 컬렉션에 commissions 컬렉션을 추가하려고 하였으나 그렇게 할 경우 중복 데이터가 너무 많아진다고 판단했습니다.

또는 RDMS의 Join과 비슷하게, user 컬렉션의 commissions에 commissions id를 배열을 저장한 뒤
commission 컬렉션을 만들어 순회하며 자신의 commission을 찾는 방식 또한 고민했습니다.

하지만 그렇게 해도 존재하는 모든 포트폴리오의 커미션 전체를 순회하는 건 마찬가지입니다.
게다가 중복 데이터만 더 늘어나 커미션 하나를 수정/삭제 했을 때 함께 고쳐야 하는 다른 컬렉션들이 너무 많아졌습니다.

따라서 반복 횟수는 동일하되 중복 데이터는 제일 적은 기존 방식을 택하기로 했습니다.
데이터가 많지 않은 프로젝트이기 때문에 반복 횟수를 걱정하기 보단 코드의 복잡성을 줄이는 게 낫다고 판단하였습니다.