### PR TITLE
Fix: 무한스크롤 뒤로가기 에러를 해결한다.

### DIFF
--- a/src/components/molecules/portfolio-card/PortfolioCard.tsx
+++ b/src/components/molecules/portfolio-card/PortfolioCard.tsx
@@ -15,7 +15,7 @@ type Props = HTMLAttributes<HTMLDivElement> & {
 	portfolio: any;
 }
 
-export default function PortfolioCard({ portfolio }: Props) {
+export default function PortfolioCard({ portfolio, ...props }: Props) {
 	const buttonGroupRef = useRef(null);
 	const currentSection = useSelector(section);
 
@@ -32,8 +32,11 @@ export default function PortfolioCard({ portfolio }: Props) {
 	}, [isPopUp])
 
 	return (
-		<S.Wrapper>
-			<PortfolioSlider section={currentSection} portfolio={portfolio}/>
+		<S.Wrapper {...props}>
+			<PortfolioSlider
+				section={currentSection}
+				portfolio={portfolio}
+			/>
 
 			<S.ProfileBox>
 				<Profile type='portfolio-card' portfolio={portfolio} user={portfolio.user}/>

--- a/src/components/organisms/portfolio-list/PortfolioList.tsx
+++ b/src/components/organisms/portfolio-list/PortfolioList.tsx
@@ -11,13 +11,13 @@ import { usePortfoliosQuery } from "@/utils";
 
 import { PortfolioCard, Text } from "@/components";
 
+export const SESSION_STORAGE_KEY = 'lastClickedPortfolio';
+
 type Props = {
 	category: string;
 };
 
 const ITEMS_PER_SHOW = 6;
-
-export const SESSION_STORAGE_KEY = "lastClickedPortfolio";
 
 export default function PortfolioList({ category }: Props) {
 	const [showsNum, setShowsNum] = useState<number>(ITEMS_PER_SHOW);
@@ -44,7 +44,7 @@ export default function PortfolioList({ category }: Props) {
 
 	const setObservationTarget = useIntersectionObserver(loadNextPage);
 
-	const saveScroll = (index: number) => {
+	const saveScrollAndPage = (index: number) => {
     sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify({
       anchorPosition: window.pageYOffset,
       clickedPortfolioIndex: index,
@@ -55,24 +55,32 @@ export default function PortfolioList({ category }: Props) {
 		const getStorage = sessionStorage.getItem(SESSION_STORAGE_KEY);
 		if(!getStorage) return;
 
-		const { anchorPosition } = JSON.parse(getStorage);
+		const { anchorPosition, clickedPortfolioIndex } = JSON.parse(getStorage);
+
+		setShowsNum(clickedPortfolioIndex);
+
 		setTimeout(() => {
       window.scrollTo({
         top: anchorPosition,
       });
-    }, 1000);
+    }, 500);
 		return () => sessionStorage.removeItem(SESSION_STORAGE_KEY);
 	}, []);
 
 	useEffect(() => {
-		const isLastPortfoliosLessThanPerShows = showsNum + ITEMS_PER_SHOW > portfolios.length;
+		const isLastPortfoliosLessThanPerShow = portfolios.length - showsNum < ITEMS_PER_SHOW;
 
-		if(isLastPortfoliosLessThanPerShows) {
+		if(!hasNextPage && showsNum < portfolios.length) {
+			setShowsNum(portfolios.length);
+		}
+
+		if(isLastPortfoliosLessThanPerShow) {
 			setShowsNum(prev => prev + (portfolios.length - showsNum));
 			return;
 		}
+
 		setShowsNum(prev => prev + ITEMS_PER_SHOW);
-	}, [portfolios]);
+	}, [portfolios, hasNextPage]);
 
 	return (
 		<S.Wrapper>
@@ -82,9 +90,9 @@ export default function PortfolioList({ category }: Props) {
 						if(index < showsNum) {
 							return(
 								<PortfolioCard
-									key={index}
+									key={portfolio.id}
 									portfolio={portfolio}
-									onClick={() => saveScroll(++index)}
+									onClick={() => saveScrollAndPage(++index)}
 								/>
 							)
 					}})

--- a/src/components/organisms/slider/portfolio-slider/PortfolioSlider.tsx
+++ b/src/components/organisms/slider/portfolio-slider/PortfolioSlider.tsx
@@ -43,7 +43,10 @@ export default function PortfolioSlider({section, portfolio}: Props){
 		<S.Wrapper
 			$section={section}
 			$isMoreThanOnePage={portfolio.images.length > 0}
-			onClick={() => navigate(`/portfolios/${portfolio.id}`)}
+			onClick={() => navigate(
+				`/portfolios/${portfolio.id}`,
+				{state: {prevPathname: 'main'}})
+			}
 		>
 			<S.Content className={`${sectionClassName}-slider-box`}>
 				<S.ArrowBox onClick={eventStopPropagation}>

--- a/src/pages/portfolio-detail/PortfolioDetailPage.tsx
+++ b/src/pages/portfolio-detail/PortfolioDetailPage.tsx
@@ -1,19 +1,21 @@
 import { useEffect } from "react";
 import { FiChevronRight as ChevronRightIcon , FiArrowLeft as LeftArrowIcon } from "react-icons/fi";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 
+import { SESSION_STORAGE_KEY } from "@/components/organisms/portfolio-list/PortfolioList";
 import * as S from "@/pages/portfolio-detail/PortfolioDetailPage.styled";
 
 import type { Portfolio } from "@/types";
 
 import { useHtmlContent, usePageErrorAlert } from "@/hooks";
-import { setAlert, userState, section } from "@/redux";
+import { setAlert, userState } from "@/redux";
 import { usePortfolioDeleteQuery, usePortfolioDetailQuery, toUrlParameter } from "@/utils";
 
 import { Text, Image, Button, ToggleButton, Tag, Profile } from "@/components";
 
 export default function PortfolioDetail(){
+	const location = useLocation();
 	const dispatch = useDispatch();
 	const navigate = useNavigate();
 
@@ -24,6 +26,15 @@ export default function PortfolioDetail(){
 	const { sanitize, setElementInlineStyle } = useHtmlContent();
 	const { data: portfolio, isError } = usePortfolioDetailQuery(portfolioId);
 	usePageErrorAlert(isError);
+
+	const handleGoBackButton = () => {
+		if(location.state?.prevPathname === 'main') {
+			navigate(-1);
+			return;
+		}
+		sessionStorage.removeItem(SESSION_STORAGE_KEY);
+		return navigate(`/main/${toUrlParameter(portfolio?.section)}`);
+	};
 
 	const handleEditButton = () => {
 		navigate(`/portfolios/edit?id=${portfolio?.id}`, {state: portfolio});
@@ -40,11 +51,15 @@ export default function PortfolioDetail(){
 		await deletePorfolioMutation.mutate();
 	};
 
+	useEffect(() => {
+		window.scrollTo(0, 0);
+	}, []);
+
 	return(
 		<S.Wrapper>
 			<LeftArrowIcon
 				size={20}
-				onClick={()=>navigate(-1)}
+				onClick={handleGoBackButton}
 			/>
 
 			<S.Content>


### PR DESCRIPTION
## 개요
`MainPage.tsx` 페이지의 `PortfolioCardList.tsx` 무한 스크롤 뒤로가기 시 마지막 스크롤 위치를 기억하지 못하는 에러를 해결합니다. 

## 작업사항
* 무한스크롤 중간에 포트폴리오 클릭 후, 뒤로가기를 클릭하면 이전 스크롤 위치를 기억한다.
  * sessionStorage에 이전 스크롤 위치 `anchorPosition`를 기억한다.
  * sessionStorage에 클릭한 포트폴리오 인덱스 `clickedPortfolioIndex`를 저장한다.
  * 페이지 렌더링 시 `showsNum`을 `clickedPortfolioIndex`로 바꿔 필요한 개수만큼 `PortfolioCard.tsx`를 렌더링한다.
* `PortfolioDetailPage.tsx` 뒤로가기 버튼을 경우에 따라 다르게 한다.
  * 바로 이전 페이지가 `MainPage.tsx` 무한스크롤인 경우 마지막 스크롤 위치로 돌아간다.
  * 중간에 다른 경로 방문 후 뒤로가기 클릭 시 해당 포트폴리오 section 목록 최상단으로 이동한다.

## 변경로직
* `PortfolioCard.tsx`를 클릭 후 ` PortfolioDetailPage.tsx` 페이지로 navigate할 때, {state: prevPathname: 'main'}} 상태값을 함께 보낸다.
* ` PortfolioDetailPage.tsx` 페이지에서 뒤로가기 클릭 시 `location.prevPathname`이 'main'이 아닌 경우 현재 포트폴리오 section 목록으로 이동한다.
  * `sessionStorage`에 저장된 무한스크롤 스크롤 위치를 삭제하고 최상단으로 이동한다.

### 변경전
  * ex) 무한 스크롤 -> 포트폴리오 디테일 페이지 -> 마이 페이지(등 다른 페이지) -> 뒤로가기 -> 포트폴리오 디테일 페이지 -> 뒤로가기 시 무한 스크롤 페이지로 돌아가지 않고 중간에 방문한 다른 페이지로 이동한다.
  * 사용자 경험을 위해 `/main/:section`으로 이동시킨다.

### 변경후

https://github.com/Kim-DaHam/Portfolly/assets/81691456/9de5197e-324a-4650-889b-0ccc17759803

