### PR TITLE
Fix: MessagePage.tsx에 NoSQL형식 더미 데이터를 불러온다

### DIFF
--- a/src/components/molecules/items/messageRoom-item/MessageRoomItem.tsx
+++ b/src/components/molecules/items/messageRoom-item/MessageRoomItem.tsx
@@ -2,25 +2,25 @@ import { useNavigate } from 'react-router-dom';
 
 import * as S from '@/components/molecules/items/messageRoom-item/MessageRoomItem.styled';
 
-import { toLocalDateString } from '@/utils';
+import type { MessageRoom } from '@/types';
 
 import { Image, Text } from '@/components';
 
 type Props = {
-	message: any;
+	messageRoom: MessageRoom;
 }
 
-export default function MessageRoomItem({ message }: Props) {
+export default function MessageRoomItem({ messageRoom }: Props) {
 	const navigate = useNavigate();
 
 	const searchParams = new URL(window.location.href).searchParams;
 	const partnerId = searchParams.get('partner_id') as string;
-	const isClicked = Number(partnerId) === message.partner.id;
+	const isClicked = partnerId === messageRoom.partner!.id;
 
 	return (
-		<S.Wrapper onClick={() => navigate(`/messages?partner_id=${message.partner.id}`)} $isClicked={isClicked}>
+		<S.Wrapper onClick={() => navigate(`/messages?partner_id=${messageRoom.partner!.id}`)} $isClicked={isClicked}>
 			<Image
-				src={message.partner.profileImage}
+				src={messageRoom.partner!.profileImage}
 				alt='사용자 프로필'
 				size='3.2rem'
 				shape='circle'
@@ -28,12 +28,16 @@ export default function MessageRoomItem({ message }: Props) {
 
 			<S.Box>
 				<S.LabelBox>
-					<Text size='label'>{message.partner.nickname}</Text>
-					<Text size='label' color='gray'>{toLocalDateString(new Date(message.timestamp))}</Text>
+					<Text size='label'>{messageRoom.partner!.nickname}</Text>
+					<Text size='label' color='gray'>
+
+					</Text>
 				</S.LabelBox>
 
 				<S.MessageBox>
-					<Text size='bodyMedium'>{message.lastMessage}</Text>
+					<Text size='bodyMedium'>
+
+					</Text>
 				</S.MessageBox>
 			</S.Box>
 		</S.Wrapper>

--- a/src/components/molecules/message/Message.tsx
+++ b/src/components/molecules/message/Message.tsx
@@ -14,7 +14,7 @@ type Props = {
 
 export default function Message({ message, partnerProfileImage }: Props) {
 	const { id: userId } = useSelector(userState);
-	const isOwned = message.userId === userId ? true : false;
+	const isOwned = message.from.id === userId ? true : false;
 
 	return (
 		<S.Wrapper $isOwned={isOwned}>

--- a/src/components/organisms/file-modal/FileModal.styled.tsx
+++ b/src/components/organisms/file-modal/FileModal.styled.tsx
@@ -1,8 +1,7 @@
 import styled from "styled-components";
 
 export const Wrapper = styled.div`
-	min-width: 100%;
-	width: fit-content;
+	width: 100%;
 	height: fit-content;
 
 	position: sticky;

--- a/src/components/organisms/message-list/MessageList.styled.tsx
+++ b/src/components/organisms/message-list/MessageList.styled.tsx
@@ -2,13 +2,15 @@ import styled from "styled-components";
 
 export const Wrapper = styled.div`
 	width: 100%;
-	height: 100%;
-
-	display: flex;
-	flex-direction: column;
-
+	min-height: 100%;
 	position: relative;
 	overflow-y: scroll;
+`;
+
+export const Content = styled.div`
+	width: 100%;
+	height: fit-content;
+	position: relative;
 `;
 
 export const Notification = styled.div`

--- a/src/components/organisms/message-list/MessageList.tsx
+++ b/src/components/organisms/message-list/MessageList.tsx
@@ -25,27 +25,27 @@ export default function MessageList({ messageList={}, getValues, setValue, isFil
 
 	return (
 		<S.Wrapper id='message-box'>
-			<>
-			{ messageKeys.length > 0 ?
-				<>
-				{ messageKeys.map((docKey: string) => {
-					return (
-						<Message
-							key={docKey}
-							message={messageList[docKey]}
-							partnerProfileImage={messageList[docKey].from.profileImage}
-						/>
-					)
-				})}
-				</>
-				:
-				<S.Notification>
-					<Text size='label' color='lightgray'>
-						아직 메세지가 없어요.
-					</Text>
-				</S.Notification>
-			}
-			</>
+			<S.Content>
+				{ messageKeys.length > 0 ?
+					<>
+					{ messageKeys.map((docKey: string) => {
+						return (
+							<Message
+								key={docKey}
+								message={messageList[docKey]}
+								partnerProfileImage={messageList[docKey].from.profileImage}
+							/>
+						)
+					})}
+					</>
+					:
+					<S.Notification>
+						<Text size='label' color='lightgray'>
+							아직 메세지가 없어요.
+						</Text>
+					</S.Notification>
+				}
+			</S.Content>
 
 			{ isFileModalOpen &&
 				<FileModal

--- a/src/components/organisms/message-list/MessageList.tsx
+++ b/src/components/organisms/message-list/MessageList.tsx
@@ -3,19 +3,20 @@ import { UseFormGetValues, UseFormSetValue } from 'react-hook-form';
 
 import * as S from '@/components/organisms/message-list/MessageList.styled';
 
-import type { SetState } from '@/types';
+import type { Messages, SetState } from '@/types';
 
 import { Text, FileModal, Message } from '@/components';
 
 type Props = {
-	message: any;
+	messageList: Messages;
 	getValues: UseFormGetValues<any>;
 	setValue: UseFormSetValue<any>;
 	isFileModalOpen: boolean;
 	handleFileModal: SetState<boolean>;
 };
 
-export default function MessageList({ message, getValues, setValue, isFileModalOpen, handleFileModal }: Props) {
+export default function MessageList({ messageList={}, getValues, setValue, isFileModalOpen, handleFileModal }: Props) {
+	const messageKeys = Object.keys(messageList);
 
 	useEffect(() => {
 		const messageBox = document.querySelector('#message-box') as HTMLElement;
@@ -25,14 +26,14 @@ export default function MessageList({ message, getValues, setValue, isFileModalO
 	return (
 		<S.Wrapper id='message-box'>
 			<>
-			{ message.messages.length > 0 ?
+			{ messageKeys.length > 0 ?
 				<>
-				{ message.messages.map((item: any) => {
+				{ messageKeys.map((docKey: string) => {
 					return (
 						<Message
-							message={item}
-							key={item.id}
-							partnerProfileImage={message.partner.profileImage}
+							key={docKey}
+							message={messageList[docKey]}
+							partnerProfileImage={messageList[docKey].from.profileImage}
 						/>
 					)
 				})}

--- a/src/components/organisms/message-room-list/MessageRoomList.styled.tsx
+++ b/src/components/organisms/message-room-list/MessageRoomList.styled.tsx
@@ -4,6 +4,7 @@ import * as mixins from '@/styles/mixins';
 
 export const Wrapper = styled.aside`
 	width: 19rem;
+	height: 100%;
 	${mixins.flexColumn}
 	flex: none;
 `;

--- a/src/components/organisms/message-room-list/MessageRoomList.tsx
+++ b/src/components/organisms/message-room-list/MessageRoomList.tsx
@@ -1,38 +1,40 @@
 import { useEffect, useState } from "react";
 
 import * as S from '@/components/organisms/message-room-list/MessageRoomList.styled';
+import { MessageStatus, type MessageRoom } from "@/types";
 
-import { Text, MessageRoomItem, Selector } from "@/components";
+import { Text, MessageRoomItem, Selector, MessageList } from "@/components";
 
 type Props = {
-	messageRooms: any;
+	messageRoomList: MessageRoom[];
 }
 
-export default function MessageRoomList({ messageRooms }: Props) {
-	const [messageFilter, setMessageFilter] = useState('전체');
-	const [filteredMessageRooms, setFilteredMessageRooms] = useState<any[]>([]);
+export default function MessageRoomList({ messageRoomList }: Props) {
+	const [messageFilter, setMessageFilter] = useState<MessageStatus | '전체'>('전체');
+	const [filteredMessageRooms, setFilteredMessageRooms] = useState<MessageRoom[]>([]);
 
 	const filterMessageRooms = () => {
 		if(messageFilter === '전체') {
-			return setFilteredMessageRooms(messageRooms);
+			setFilteredMessageRooms(messageRoomList);
 		}
 		if(messageFilter === '안 읽음') {
-			const filteredRooms = messageRooms.filter((room: any) => {
+			const filteredRooms = messageRoomList.filter((room: any) => {
 				return room.isRead === false;
 			})
-			return setFilteredMessageRooms(filteredRooms);
+			setFilteredMessageRooms(filteredRooms);
 		}
 		if(messageFilter === '거래 중') {
-			const filteredRooms = messageRooms.filter((message: any) => {
+			const filteredRooms = messageRoomList.filter((message: any) => {
 				return message.commissionStatus !== '구매 확정' && message.commissionStatus !== null;
 			})
-			return setFilteredMessageRooms(filteredRooms);
+			setFilteredMessageRooms(filteredRooms);
 		}
+		return;
 	};
 
 	useEffect(() => {
 		filterMessageRooms();
-	}, [messageFilter]);
+	}, [messageFilter, messageRoomList]);
 
 	return (
 		<S.Wrapper>
@@ -46,10 +48,10 @@ export default function MessageRoomList({ messageRooms }: Props) {
 			</S.SearchBox>
 
 			<S.MessageRoomBox>
-				{ filteredMessageRooms.length > 0 ?
+				{ filteredMessageRooms?.length > 0 ?
 					<>
-						{ filteredMessageRooms.map((room: any) => {
-								return <MessageRoomItem message={room} key={room.id}/>
+						{ filteredMessageRooms?.map((room: any) => {
+								return <MessageRoomItem messageRoom={room} key={room.id}/>
 						})}
 					</>
 					:

--- a/src/components/organisms/message-room-list/MessageRoomList.tsx
+++ b/src/components/organisms/message-room-list/MessageRoomList.tsx
@@ -3,15 +3,15 @@ import { useEffect, useState } from "react";
 import * as S from '@/components/organisms/message-room-list/MessageRoomList.styled';
 import { MessageStatus, type MessageRoom } from "@/types";
 
-import { Text, MessageRoomItem, Selector, MessageList } from "@/components";
+import { useMessageRoomsQuery } from "@/utils";
 
-type Props = {
-	messageRoomList: MessageRoom[];
-}
+import { Text, MessageRoomItem, Selector } from "@/components";
 
-export default function MessageRoomList({ messageRoomList }: Props) {
+export default function MessageRoomList() {
 	const [messageFilter, setMessageFilter] = useState<MessageStatus | '전체'>('전체');
 	const [filteredMessageRooms, setFilteredMessageRooms] = useState<MessageRoom[]>([]);
+
+	const { data: messageRoomList } = useMessageRoomsQuery();
 
 	const filterMessageRooms = () => {
 		if(messageFilter === '전체') {

--- a/src/components/organisms/message-room/MessageRoom.styled.tsx
+++ b/src/components/organisms/message-room/MessageRoom.styled.tsx
@@ -5,7 +5,6 @@ import * as mixins from '@/styles/mixins';
 export const Wrapper = styled.section`
 	${mixins.fullWidthHeight}
 	${mixins.flexColumn}
-	flex-basis: 1;
 
 	overflow: hidden;
 `;
@@ -42,7 +41,8 @@ export const InputBox = styled.div`
 
 export const TextArea = styled.textarea`
 	width: 100%;
-	height: 3rem;
+	height: fit-content;
+	flex: none;
 	padding: 0.5rem 1.2rem;
 	border-radius: 1rem;
 	border: 1px solid #e8e9f0;
@@ -71,6 +71,7 @@ export const Label = styled.label`
 `;
 
 export const Box = styled.div`
+	height: 100%;
 	${mixins.flexRow}
 	flex-basis: 1;
 	justify-content: space-between;

--- a/src/components/organisms/message-room/MessageRoom.styled.tsx
+++ b/src/components/organisms/message-room/MessageRoom.styled.tsx
@@ -71,7 +71,7 @@ export const Label = styled.label`
 `;
 
 export const Box = styled.div`
-	height: 100%;
+	${mixins.fullWidthHeight}
 	${mixins.flexRow}
 	flex-basis: 1;
 	justify-content: space-between;

--- a/src/components/organisms/message-room/MessageRoom.tsx
+++ b/src/components/organisms/message-room/MessageRoom.tsx
@@ -7,7 +7,7 @@ import { useDispatch } from "react-redux";
 import * as S from '@/components/organisms/message-room/MessageRoom.styled';
 import { setToast } from "@/redux/toastSlice";
 
-import type { Authority, MessageRoom } from "@/types";
+import type { MessageRoom } from "@/types";
 
 import { useMessageRoomDeleteMutation } from "@/utils";
 

--- a/src/components/organisms/message-room/MessageRoom.tsx
+++ b/src/components/organisms/message-room/MessageRoom.tsx
@@ -7,12 +7,14 @@ import { useDispatch } from "react-redux";
 import * as S from '@/components/organisms/message-room/MessageRoom.styled';
 import { setToast } from "@/redux/toastSlice";
 
+import type { Authority, MessageRoom } from "@/types";
+
 import { useMessageRoomDeleteMutation } from "@/utils";
 
 import { Text, AlertModal, PartnerProfile, MessageList, Button } from '@/components';
 
 type Props = {
-	message: any;
+	messageRoom: MessageRoom;
 }
 
 export type FormValues = {
@@ -27,13 +29,13 @@ const defaultValues: FormValues = {
 	memo: '',
 };
 
-export default function MessageRoom({ message }: Props) {
+export default function MessageRoom({ messageRoom }: Props) {
 	const [isFileModalOpen, setIsFileModalOpen] = useState(false);
 	const [isExitModalOpen, setIsExitModalOpen] = useState(false);
 
 	const dispatch = useDispatch();
 
-	const deleteMessageRoomMutation = useMessageRoomDeleteMutation(message.partner.id);
+	const deleteMessageRoomMutation = useMessageRoomDeleteMutation(messageRoom.partner!.id);
 
 	const { register, handleSubmit, setValue, getValues } = useForm<FormValues>({
 		mode: 'onSubmit',
@@ -64,23 +66,26 @@ export default function MessageRoom({ message }: Props) {
 	return (
 		<S.Wrapper>
 			<S.TitleBox>
-				<Text size='label'>{message.partner.nickname}</Text>
+				<Text size='label'>{messageRoom.partner?.nickname}</Text>
 				<ExitIcon size={24} onClick={() => setIsExitModalOpen(prev=>!prev)}/>
 			</S.TitleBox>
 
 			<S.Box>
 				<MessageList
-					message={message}
+					messageList={messageRoom.messages!}
 					setValue={setValue}
 					getValues={getValues}
 					isFileModalOpen={isFileModalOpen}
 					handleFileModal={setIsFileModalOpen}
 				/>
-				<PartnerProfile message={message} />
+				<PartnerProfile
+					messageRoom={messageRoom}
+				/>
 			</S.Box>
 
 			<S.InputBox>
 				<S.TextArea
+					placeholder='메세지를 입력하세요.'
 					{...register('message', {
 						required: '메시지를 입력하세요',
 					})}

--- a/src/components/organisms/modal/commission-modal/CommissionModal.tsx
+++ b/src/components/organisms/modal/commission-modal/CommissionModal.tsx
@@ -115,7 +115,7 @@ export default function CommissionModal({ commission, handleModal, editMode, $mo
 							/>
 							:
 							<Text size='titleSmall'>
-								{commission.details.title}
+								{commission.details?.title}
 							</Text>
 						}
 
@@ -160,7 +160,7 @@ export default function CommissionModal({ commission, handleModal, editMode, $mo
 							})} />
 							:
 							<Text size='bodyMedium'>
-								{commission.details.content}
+								{commission.details?.content}
 							</Text>
 						}
 					</S.Box>
@@ -175,7 +175,7 @@ export default function CommissionModal({ commission, handleModal, editMode, $mo
 							})} />
 							:
 							<Text size='bodyMedium'>
-								{commission.details.deadline}
+								{commission.details?.deadline}
 							</Text>
 						}
 					</S.Box>
@@ -188,7 +188,7 @@ export default function CommissionModal({ commission, handleModal, editMode, $mo
 							})} />
 							:
 							<Text size='bodyMedium'>
-								{commission.details.cost}
+								{commission.details?.cost}
 							</Text>
 						}
 					</S.Box>
@@ -205,7 +205,7 @@ export default function CommissionModal({ commission, handleModal, editMode, $mo
 				</S.Form>
 
 				<S.ButtonGroup>
-					{ authority === 'expert' && !isEditMode && commission.details.status !== '구매 확정' &&
+					{ authority === 'expert' && !isEditMode && commission.details?.status !== '구매 확정' &&
 						<Button
 							color='black'
 							size='medium'
@@ -214,7 +214,7 @@ export default function CommissionModal({ commission, handleModal, editMode, $mo
 							의뢰 수정
 						</Button>
 					}
-					{ authority === 'client' && commission.details.status !== '구매 확정' &&
+					{ authority === 'client' && commission.details?.status !== '구매 확정' &&
 						<Button
 							color='black'
 							size='medium'

--- a/src/components/organisms/partner-profile/PartnerProfile.tsx
+++ b/src/components/organisms/partner-profile/PartnerProfile.tsx
@@ -4,76 +4,77 @@ import { useSelector } from "react-redux";
 import * as S from "@/components/organisms/partner-profile/PartnerProfile.styled";
 import { userState } from "@/redux/loginSlice";
 
+import type { Authority, Commission, MessageRoom } from "@/types";
+
 import { useModal } from "@/hooks";
 import { toLocalDateString } from "@/utils";
 
 import { Text, Button, Profile, CommissionModal } from "@/components";
 
 type Props = {
-	message: any;
+	messageRoom: MessageRoom;
 };
 
-export default function PartnerProfile({ message }: Props) {
-	const queryClient = useQueryClient();
-
+export default function PartnerProfile({ messageRoom }: Props) {
 	const { authority } = useSelector(userState);
 	const { isModalOpen, handleModal} = useModal();
 
-	const messageQuery = queryClient.getQueryData(['message', `${message.partner.id}`]) as any;
-
-	const initialCommission = {
-		id: undefined,
-		portfolioId: message.portfolioId,
-		clientId: message.clientId,
-		portfolio: message.portfolio,
-		createdAt: toLocalDateString(new Date(Date.now())),
-		expert: message.portfolio.expert,
+	const initialCommission: Commission = {
+		createdAt: toLocalDateString(Date.now()),
+		endedAt: null,
+		review: null,
+		portfolio: messageRoom.portfolio,
+		client: messageRoom.client!,
+		expert: messageRoom.expert,
 	};
-
-	console.log(message)
 
 	return(
 		<S.Wrapper>
-			<Profile type='message-room' user={message.partner} />
+			<Profile type='message-room' user={messageRoom.partner} />
 
 			<S.ActivityBox>
 				<S.Box>
 					<Text size='label'>만족도</Text>
-					<Text size='label'>{message.partner.score}</Text>
+					<Text size='label'>{messageRoom.partner?.profile.score}</Text>
 				</S.Box>
 				<S.Box>
 					<Text size='label'>연락 가능 시간</Text>
-					<Text size='label'>{message.partner.contactTime}</Text>
+					<Text size='label'>{messageRoom.partner?.profile.contactTime}</Text>
 				</S.Box>
 			</S.ActivityBox>
 
 			<Text size='label'>전문가 서비스</Text>
-			<Profile type='portfolio' portfolio={message.portfolio} />
+			<Profile type='portfolio' portfolio={messageRoom.portfolio} />
 
-			{ !message.commission && authority === 'expert' &&
+			{ !messageRoom.commission && authority === 'expert' &&
 				<>
 					<Button color='black' size='full' onClick={handleModal}>
 						의뢰 폼 작성
 					</Button>
 
 					<CommissionModal
-					editMode
-					commission={initialCommission}
-					handleModal={handleModal}
-					$modalState={isModalOpen}
+						editMode
+						commission={initialCommission}
+						handleModal={handleModal}
+						$modalState={isModalOpen}
 					/>
 				</>
 			}
 
-			{ message.commission &&
+			{ messageRoom.commission &&
 				<Button color='gray' size='full' onClick={handleModal}>
 					의뢰 폼 확인
 				</Button>
 			}
 
-			{ messageQuery && message.commission &&
+			{ messageRoom.commission &&
 				<CommissionModal
-					commission={messageQuery.commission}
+					commission={{
+						...messageRoom.commission,
+						client: messageRoom.client!,
+						expert: messageRoom.expert,
+						portfolio: messageRoom.portfolio,
+					}}
 					handleModal={handleModal}
 					$modalState={isModalOpen}
 				/>

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -4,9 +4,11 @@ import { PortfolioHandlers } from "./portfolio";
 import { toggleButtonHandlers } from "./toggleButton";
 import { userHandlers } from "./user";
 
+import type { Authority } from "@/types";
+
 export const LOGIN_ID = 'client1';
-export const AUTHORITY: string = 'client';
-export const PARTNER_ID = AUTHORITY === 'expert' ? 'clientId' : 'expertId';
+export const AUTHORITY: Authority = 'client';
+export const PARTNER_AUTHORITY = AUTHORITY === String('expert') ? 'client' : 'expert';
 export const MY_ID = AUTHORITY + 'Id';
 
 export const handlers = PortfolioHandlers

--- a/src/mocks/handlers/message.ts
+++ b/src/mocks/handlers/message.ts
@@ -7,14 +7,10 @@ import { AUTHORITY, LOGIN_ID, MY_ID, PARTNER_AUTHORITY } from '.';
 import type { MessageRoom } from '@/types';
 
 export const messageHandlers= [
-	http.get('/messageRoom', ({request}) => {
-		const url = new URL(request.url);
-		const partnerId = url.searchParams.get('partner_id') as string;
-
+	// 대화방 목록 가져오기
+	http.get('/messageRooms', () => {
 		const messageRoomsDocKeys: string[] = Object.keys(messageRooms);
-
 		const messageRoomList: MessageRoom[] = [];
-		const messageRoom: any & MessageRoom = {};
 
 		messageRoomsDocKeys.forEach((docKey: any) => {
 			const room = messageRooms[docKey];
@@ -27,7 +23,26 @@ export const messageHandlers= [
 					partner: room[PARTNER_AUTHORITY],
 					commission: room.commission,
 				});
+			}
+		});
 
+		return HttpResponse.json(messageRoomList, { status: 200 });
+	}),
+
+	// 특정 대화방 가져오기
+	http.get('/messageRoom', ({request}) => {
+		const url = new URL(request.url);
+		const partnerId = url.searchParams.get('partner_id') as string;
+
+		const messageRoomsDocKeys: string[] = Object.keys(messageRooms);
+
+		const messageRoom: any & MessageRoom = {};
+
+		messageRoomsDocKeys.forEach((docKey: any) => {
+			const room = messageRooms[docKey];
+			const isMyMessageRoom = room[AUTHORITY]?.id === LOGIN_ID;
+
+			if(isMyMessageRoom) {
 				// '/messages' 경로로 들어와 partnerId가 존재하지 않을 경우 가장 첫 번째 messageRoom 정보를 제공한다.
 				if(partnerId === room[PARTNER_AUTHORITY]?.id) {
 					Object.assign(messageRoom, {
@@ -39,11 +54,10 @@ export const messageHandlers= [
 		});
 
 		const responseData = {
-			messageRoomList: messageRoomList,
 			messageRoom: Object.keys(messageRoom).length > 0 ? messageRoom : null,
 		};
 
-		return HttpResponse.json(responseData, { status: 200 });
+		return HttpResponse.json(responseData.messageRoom, { status: 200 });
 	}),
 
 	// 메세지룸 삭제

--- a/src/mocks/nosql-data/messages.ts
+++ b/src/mocks/nosql-data/messages.ts
@@ -1,7 +1,11 @@
-const messageRooms = {
+import { MessageRooms } from "@/types";
+
+import { toLocalDateString } from "@/utils";
+
+export const messageRooms: MessageRooms = {
 	room1: {
-		name: 'Room 1',
 		expert: {
+			id: 'expert1',
 			name: 'John',
 			email: 'john@example.com',
 			phone: '010-1234-1234',
@@ -13,6 +17,7 @@ const messageRooms = {
 			},
 		},
 		client: {
+			id: 'client1',
 			name: '김강철',
 			email: 'steel@example.com',
 			phone: '010-1234-1234',
@@ -51,7 +56,7 @@ const messageRooms = {
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
 				msg: 'hello',
-				createdAt: Date.now(),
+				createdAt: toLocalDateString(Date.now()),
 				isRead: true,
 			},
 			message2: {
@@ -60,14 +65,14 @@ const messageRooms = {
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
 				msg: 'hello!',
-				createdAt: Date.now(),
+				createdAt: toLocalDateString(Date.now()),
 				isRead: false,
 			}
 		}
 	},
 	room2: {
-		name: 'Room 1',
 		expert: {
+			id: 'expert1',
 			name: 'John',
 			email: 'john@example.com',
 			phone: '010-1234-1234',
@@ -79,6 +84,7 @@ const messageRooms = {
 			},
 		},
 		client: {
+			id: 'client1',
 			name: '김강철',
 			email: 'steel@example.com',
 			phone: '010-1234-1234',
@@ -117,7 +123,7 @@ const messageRooms = {
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
 				msg: 'hello',
-				createdAt: Date.now(),
+				createdAt: toLocalDateString(Date.now()),
 				isRead: true,
 			},
 			message2: {
@@ -126,14 +132,14 @@ const messageRooms = {
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
 				msg: 'hello!',
-				createdAt: Date.now(),
+				createdAt: toLocalDateString(Date.now()),
 				isRead: false,
 			}
 		}
 	},
 	room3: {
-		name: 'Room 1',
 		expert: {
+			id: 'expert1',
 			name: 'John',
 			email: 'john@example.com',
 			phone: '010-1234-1234',
@@ -145,6 +151,7 @@ const messageRooms = {
 			},
 		},
 		client: {
+			id: 'client1',
 			name: '김강철',
 			email: 'steel@example.com',
 			phone: '010-1234-1234',
@@ -183,7 +190,7 @@ const messageRooms = {
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
 				msg: 'hello',
-				createdAt: Date.now(),
+				createdAt: toLocalDateString(Date.now()),
 				isRead: true,
 			},
 			message2: {
@@ -192,14 +199,14 @@ const messageRooms = {
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
 				msg: 'hello!',
-				createdAt: Date.now(),
+				createdAt: toLocalDateString(Date.now()),
 				isRead: false,
 			}
 		}
 	},
 	room4: {
-		name: 'Room 1',
 		expert: {
+			id: 'expert1',
 			name: 'John',
 			email: 'john@example.com',
 			phone: '010-1234-1234',
@@ -211,6 +218,7 @@ const messageRooms = {
 			},
 		},
 		client: {
+			id: 'client1',
 			name: '김강철',
 			email: 'steel@example.com',
 			phone: '010-1234-1234',
@@ -249,7 +257,7 @@ const messageRooms = {
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
 				msg: 'hello',
-				createdAt: Date.now(),
+				createdAt: toLocalDateString(Date.now()),
 				isRead: true,
 			},
 			message2: {
@@ -258,14 +266,14 @@ const messageRooms = {
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
 				msg: 'hello!',
-				createdAt: Date.now(),
+				createdAt: toLocalDateString(Date.now()),
 				isRead: false,
 			}
 		}
 	},
 	room5: {
-		name: 'Room 1',
 		expert: {
+			id: 'expert1',
 			name: 'John',
 			email: 'john@example.com',
 			phone: '010-1234-1234',
@@ -277,6 +285,7 @@ const messageRooms = {
 			},
 		},
 		client: {
+			id: 'client1',
 			name: '김강철',
 			email: 'steel@example.com',
 			phone: '010-1234-1234',
@@ -315,7 +324,7 @@ const messageRooms = {
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
 				msg: 'hello',
-				createdAt: Date.now(),
+				createdAt: toLocalDateString(Date.now()),
 				isRead: true,
 			},
 			message2: {
@@ -324,7 +333,7 @@ const messageRooms = {
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
 				msg: 'hello!',
-				createdAt: Date.now(),
+				createdAt: toLocalDateString(Date.now()),
 				isRead: false,
 			}
 		}

--- a/src/mocks/nosql-data/messages.ts
+++ b/src/mocks/nosql-data/messages.ts
@@ -72,7 +72,7 @@ export const messageRooms: MessageRooms = {
 	},
 	room2: {
 		expert: {
-			id: 'expert1',
+			id: 'expert2',
 			name: 'John',
 			email: 'john@example.com',
 			phone: '010-1234-1234',
@@ -139,7 +139,7 @@ export const messageRooms: MessageRooms = {
 	},
 	room3: {
 		expert: {
-			id: 'expert1',
+			id: 'expert3',
 			name: 'John',
 			email: 'john@example.com',
 			phone: '010-1234-1234',
@@ -206,7 +206,7 @@ export const messageRooms: MessageRooms = {
 	},
 	room4: {
 		expert: {
-			id: 'expert1',
+			id: 'expert4',
 			name: 'John',
 			email: 'john@example.com',
 			phone: '010-1234-1234',
@@ -273,7 +273,7 @@ export const messageRooms: MessageRooms = {
 	},
 	room5: {
 		expert: {
-			id: 'expert1',
+			id: 'expert5',
 			name: 'John',
 			email: 'john@example.com',
 			phone: '010-1234-1234',

--- a/src/mocks/nosql-data/messages.ts
+++ b/src/mocks/nosql-data/messages.ts
@@ -52,22 +52,124 @@ export const messageRooms: MessageRooms = {
 		messages: {
 			message1: {
 				from: {
+					id: 'expert1',
 					nickname: 'John',
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
-				msg: 'hello',
+				message: 'hello',
 				createdAt: toLocalDateString(Date.now()),
 				isRead: true,
 			},
 			message2: {
 				from: {
+					id: 'client1',
 					nickname: 'Paul',
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
-				msg: 'hello!',
+				message: 'hello!',
 				createdAt: toLocalDateString(Date.now()),
 				isRead: false,
-			}
+			},
+			message3: {
+				from: {
+					id: 'expert1',
+					nickname: 'John',
+					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
+				},
+				message: 'hello',
+				createdAt: toLocalDateString(Date.now()),
+				isRead: true,
+			},
+			message4: {
+				from: {
+					id: 'client1',
+					nickname: 'Paul',
+					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
+				},
+				message: 'hello!',
+				createdAt: toLocalDateString(Date.now()),
+				isRead: false,
+			},
+			message5: {
+				from: {
+					id: 'expert1',
+					nickname: 'John',
+					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
+				},
+				message: 'hello',
+				createdAt: toLocalDateString(Date.now()),
+				isRead: true,
+			},
+			message6: {
+				from: {
+					id: 'client1',
+					nickname: 'Paul',
+					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
+				},
+				message: 'hello!',
+				createdAt: toLocalDateString(Date.now()),
+				isRead: false,
+			},
+			message7: {
+				from: {
+					id: 'expert1',
+					nickname: 'John',
+					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
+				},
+				message: 'hello',
+				createdAt: toLocalDateString(Date.now()),
+				isRead: true,
+			},
+			message8: {
+				from: {
+					id: 'client1',
+					nickname: 'Paul',
+					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
+				},
+				message: 'hello!',
+				createdAt: toLocalDateString(Date.now()),
+				isRead: false,
+			},
+			message9: {
+				from: {
+					id: 'expert1',
+					nickname: 'John',
+					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
+				},
+				message: 'hello',
+				createdAt: toLocalDateString(Date.now()),
+				isRead: true,
+			},
+			message10: {
+				from: {
+					id: 'client1',
+					nickname: 'Paul',
+					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
+				},
+				message: 'hello!',
+				createdAt: toLocalDateString(Date.now()),
+				isRead: false,
+			},
+			message11: {
+				from: {
+					id: 'expert1',
+					nickname: 'John',
+					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
+				},
+				message: 'hello',
+				createdAt: toLocalDateString(Date.now()),
+				isRead: true,
+			},
+			message12: {
+				from: {
+					id: 'client1',
+					nickname: 'Paul',
+					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
+				},
+				message: 'hello!',
+				createdAt: toLocalDateString(Date.now()),
+				isRead: false,
+			},
 		}
 	},
 	room2: {
@@ -119,22 +221,24 @@ export const messageRooms: MessageRooms = {
 		messages: {
 			message1: {
 				from: {
+					id: 'expert1',
 					nickname: 'John',
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
-				msg: 'hello',
+				message: 'hello',
 				createdAt: toLocalDateString(Date.now()),
 				isRead: true,
 			},
 			message2: {
 				from: {
+					id: 'client1',
 					nickname: 'Paul',
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
-				msg: 'hello!',
+				message: 'hello!',
 				createdAt: toLocalDateString(Date.now()),
 				isRead: false,
-			}
+			},
 		}
 	},
 	room3: {
@@ -186,19 +290,21 @@ export const messageRooms: MessageRooms = {
 		messages: {
 			message1: {
 				from: {
+					id: 'expert1',
 					nickname: 'John',
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
-				msg: 'hello',
+				message: 'hello',
 				createdAt: toLocalDateString(Date.now()),
 				isRead: true,
 			},
 			message2: {
 				from: {
+					id: 'client1',
 					nickname: 'Paul',
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
-				msg: 'hello!',
+				message: 'hello!',
 				createdAt: toLocalDateString(Date.now()),
 				isRead: false,
 			}
@@ -253,19 +359,21 @@ export const messageRooms: MessageRooms = {
 		messages: {
 			message1: {
 				from: {
+					id: 'expert1',
 					nickname: 'John',
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
-				msg: 'hello',
+				message: 'hello',
 				createdAt: toLocalDateString(Date.now()),
 				isRead: true,
 			},
 			message2: {
 				from: {
+					id: 'client1',
 					nickname: 'Paul',
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
-				msg: 'hello!',
+				message: 'hello!',
 				createdAt: toLocalDateString(Date.now()),
 				isRead: false,
 			}
@@ -320,19 +428,21 @@ export const messageRooms: MessageRooms = {
 		messages: {
 			message1: {
 				from: {
+					id: 'expert1',
 					nickname: 'John',
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
-				msg: 'hello',
+				message: 'hello',
 				createdAt: toLocalDateString(Date.now()),
 				isRead: true,
 			},
 			message2: {
 				from: {
+					id: 'client1',
 					nickname: 'Paul',
 					profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 				},
-				msg: 'hello!',
+				message: 'hello!',
 				createdAt: toLocalDateString(Date.now()),
 				isRead: false,
 			}

--- a/src/pages/message/MessagePage.styled.tsx
+++ b/src/pages/message/MessagePage.styled.tsx
@@ -19,10 +19,10 @@ export const Content = styled.main`
 `;
 
 export const MessageSection = styled.section`
-	width: 100%;
-
-	${mixins.flexColumn}
-	flex-basis: 1;
+	width: fit-content;
+	flex: none;
+	flex-shrink: 0;
+	background-color: #f5f6fa;
 `;
 
 export const NotificationBox = styled.div`

--- a/src/pages/message/MessagePage.tsx
+++ b/src/pages/message/MessagePage.tsx
@@ -1,14 +1,18 @@
+import { useQueryErrorResetBoundary } from "@tanstack/react-query";
+import { ErrorBoundary as ApiErrorBoundary } from "react-error-boundary";
+
 import * as S from '@/pages/message/MessagePage.styled';
 
 import { usePageErrorAlert } from "@/hooks";
 import { useMessageRoomQuery } from "@/utils";
 
-import { MessageRoom, MessageRoomList, Text } from '@/components';
+import { ApiErrorFallback, MessageRoom, MessageRoomList, Text } from '@/components';
 
 export default function MessagePage() {
 	const urlParams = new URL(window.location.href).searchParams;
 	const partnerId = urlParams.get('partner_id');
 
+	const { reset } = useQueryErrorResetBoundary();
 	const { data: messageRoom, isError } = useMessageRoomQuery(partnerId);
 	usePageErrorAlert(isError);
 
@@ -17,24 +21,28 @@ export default function MessagePage() {
 	return(
 		<S.Wrapper>
 			<S.Content>
-				<MessageRoomList messageRoomList={messageRoom?.messageRoomList}/>
+				<S.MessageSection>
+					<ApiErrorBoundary FallbackComponent={ApiErrorFallback} onReset={reset}>
+						<MessageRoomList />
+					</ApiErrorBoundary>
+				</S.MessageSection>
 
-				{ messageRoom?.messageRoom ?
-					<MessageRoom
-						messageRoom={messageRoom.messageRoom}
-					/>
-					:
-					<S.NotificationBox>
-						<Text size='label'>
-							아직 메세지가 없어요.
-						</Text>
-						<Text size='bodyMedium' color='gray'>
-							Portfolly에서 원하는 전문가와 대화할 수 있어요.
-							<br/>
-							지금 바로 시작해보세요!
-						</Text>
-					</S.NotificationBox>
-				}
+					{ messageRoom?
+						<MessageRoom
+							messageRoom={messageRoom}
+						/>
+						:
+						<S.NotificationBox>
+							<Text size='label'>
+								아직 메세지가 없어요.
+							</Text>
+							<Text size='bodyMedium' color='gray'>
+								Portfolly에서 원하는 전문가와 대화할 수 있어요.
+								<br/>
+								지금 바로 시작해보세요!
+							</Text>
+						</S.NotificationBox>
+					}
 			</S.Content>
 		</S.Wrapper>
 	)

--- a/src/pages/message/MessagePage.tsx
+++ b/src/pages/message/MessagePage.tsx
@@ -1,39 +1,28 @@
-import { useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-
 import * as S from '@/pages/message/MessagePage.styled';
 
+import { usePageErrorAlert } from "@/hooks";
 import { useMessageRoomQuery } from "@/utils";
 
 import { MessageRoom, MessageRoomList, Text } from '@/components';
 
 export default function MessagePage() {
 	const urlParams = new URL(window.location.href).searchParams;
-	const partnerId = urlParams.get('partner_id') || '';
+	const partnerId = urlParams.get('partner_id');
 
-	const navigate = useNavigate();
-	const queryClient = useQueryClient();
-	const { data: message } = useMessageRoomQuery(partnerId);
+	const { data: messageRoom, isError } = useMessageRoomQuery(partnerId);
+	usePageErrorAlert(isError);
 
-	useEffect(() => {
-		if(message && message.messageRooms.length > 0 && !partnerId) {
-			navigate(`/messages?partner_id=${message.partner.id}`);
-			queryClient.removeQueries({queryKey: ['messages']});
-		}
-	}, [message]);
-
-	console.log(message)
-
-	if(!message) return null;
+	console.log(messageRoom)
 
 	return(
 		<S.Wrapper>
 			<S.Content>
-				<MessageRoomList messageRooms={message?.messageRooms}/>
+				<MessageRoomList messageRoomList={messageRoom?.messageRoomList}/>
 
-				{ message?.messageRooms.length > 0 ?
-					<MessageRoom message={message} />
+				{ messageRoom?.messageRoom ?
+					<MessageRoom
+						messageRoom={messageRoom.messageRoom}
+					/>
 					:
 					<S.NotificationBox>
 						<Text size='label'>

--- a/src/types/api-data/commission.ts
+++ b/src/types/api-data/commission.ts
@@ -11,6 +11,7 @@ export type Commission = {
 		phone: string,
 		nickname: string,
 		profileImage: string,
+		profile?: any,
 	},
 	expert?: {
 		id: string;
@@ -19,10 +20,11 @@ export type Commission = {
 		phone: string,
 		nickname: string,
 		profileImage: string,
+		profile?: any,
 	},
 	portfolio?: {
 		id: string,
-		section: string,
+		section?: string,
 		title: string,
 		summary: string,
 		thumbnailUrl: string,
@@ -30,7 +32,7 @@ export type Commission = {
 	review: Review | null,
 	createdAt: string,
 	endedAt: string | null,
-	details: CommissionDetail,
+	details?: CommissionDetail,
 };
 
 export type Review = {

--- a/src/types/api-data/message.ts
+++ b/src/types/api-data/message.ts
@@ -1,32 +1,11 @@
-import { CommissionStatus } from "..";
+import type { Authority, CommissionStatus } from "@/types";
 
 export type MessageRooms = {
 	[key in string]: MessageRoom;
 };
 
-export type MessageRoom = {
-	name: string,
-	expert: {
-		name: string,
-		email: string,
-		phone: string,
-		nickname: string,
-		profileImage: string,
-		profile: {
-			score: number,
-			contactTime: string,
-		},
-	},
-	client: {
-		name: string,
-		email: string,
-		phone: string,
-		nickname: string,
-		profileImage: string,
-		profile: {
-			contactTime: string,
-		},
-	},
+export type MessageRoom = Partner & {
+	id?:string;
 	portfolio: {
 		id: string,
 		title: string,
@@ -43,7 +22,7 @@ export type MessageRoom = {
 			cost: number,
 			status: CommissionStatus,
 			deadline: string
-		},
+		} | null,
 		review: {
 			score: number,
 			content: string,
@@ -54,6 +33,21 @@ export type MessageRoom = {
 	},
 };
 
+export type Partner = {
+	[key in Authority]: {
+		id: string,
+		name: string,
+		email: string,
+		phone: string,
+		nickname: string,
+		profileImage: string,
+		profile: {
+			score?: number,
+			contactTime: string,
+		},
+	};
+};
+
 export type Message = {
 	from: {
 		nickname: string,
@@ -62,7 +56,6 @@ export type Message = {
 	msg: string,
 	createdAt: string,
 	isRead: boolean,
-	messageStatus: MessageStatus;
 };
 
 export type MessageStatus = '안 읽음' | '거래 중';

--- a/src/types/api-data/message.ts
+++ b/src/types/api-data/message.ts
@@ -4,15 +4,20 @@ export type MessageRooms = {
 	[key in string]: MessageRoom;
 };
 
-export type MessageRoom = Partner & {
-	id?:string;
-	portfolio: {
+export type Messages = {
+	[key in string] : Message;
+};
+
+export type MessageRoom = Partners & {
+	id?:string,
+	partner?: Partner,
+	portfolio?: {
 		id: string,
 		title: string,
 		summary: string,
 		thumbnailUrl: string,
 	},
-	commission: {
+	commission?: {
 		id: string,
 		createdAt: string,
 		endedAt: string,
@@ -22,30 +27,30 @@ export type MessageRoom = Partner & {
 			cost: number,
 			status: CommissionStatus,
 			deadline: string
-		} | null,
+		},
 		review: {
 			score: number,
 			content: string,
 		},
 	},
-	messages: {
-		[key in string] : Message;
-	},
+	messages?: Messages,
+};
+
+export type Partners = {
+	[key in Authority]?: Partner
 };
 
 export type Partner = {
-	[key in Authority]: {
-		id: string,
-		name: string,
-		email: string,
-		phone: string,
-		nickname: string,
-		profileImage: string,
-		profile: {
-			score?: number,
-			contactTime: string,
-		},
-	};
+	id: string,
+	name: string,
+	email: string,
+	phone: string,
+	nickname: string,
+	profileImage: string,
+	profile: {
+		score?: number,
+		contactTime: string,
+	},
 };
 
 export type Message = {

--- a/src/types/api-data/message.ts
+++ b/src/types/api-data/message.ts
@@ -55,10 +55,11 @@ export type Partner = {
 
 export type Message = {
 	from: {
+		id: string,
 		nickname: string,
 		profileImage: string,
 	},
-	msg: string,
+	message: string,
 	createdAt: string,
 	isRead: boolean,
 };

--- a/src/types/api-data/user.ts
+++ b/src/types/api-data/user.ts
@@ -5,6 +5,7 @@ export type Users = {
 };
 
 export type User = {
+	id?: string,
 	name?: string,
 	email: string,
 	phone?: string,

--- a/src/utils/api-service/message.ts
+++ b/src/utils/api-service/message.ts
@@ -1,37 +1,63 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
+import type { MessageRoom } from "@/types";
+
+import { setToast } from "@/redux";
 import { fetch } from "@/utils";
 
 const messageKeys = {
-  all: ['messages'] as const,
+  all: ['messageRoom'] as const,
   lists: (type: string) => [...messageKeys.all, type] as const,
   list: (type: string, filters: string | object) => [...messageKeys.lists(type), { filters }] as const,
-  detail: (id: string) => ['message', id] as const,
+  detail: (id: string) => [...messageKeys.all, id] as const,
 }
 
-export const useMessageRoomQuery = (partnerId: string) => {
-	const getMessages = () => fetch(`/messageRooms?partner_id=${partnerId}&page=${1}`, 'GET');
+// 메세지룸 정보 불러오기
+export const useMessageRoomQuery = (partnerId: string | null) => {
+	const getMessageRoom = () => fetch(`/messageRoom?partner_id=${partnerId}&page=${1}`, 'GET');
 
 	return useQuery({
-		queryKey: partnerId !== '' ? messageKeys.detail(partnerId) : messageKeys.all,
-		queryFn: getMessages,
+		queryKey: partnerId ? messageKeys.detail(partnerId) : messageKeys.all,
+		queryFn: getMessageRoom,
 		staleTime: Infinity,
 		gcTime: Infinity,
+		throwOnError: false,
 	});
 };
 
+// 메세지룸 삭제하기
 export const useMessageRoomDeleteMutation = (partnerId: string) => {
 	const queryClient = useQueryClient();
+	const dispatch = useDispatch();
 	const navigate = useNavigate();
+	const messageRoom = queryClient.getQueryData(['messageRoom']) as any;
+	const copyMessageRoom = messageRoom && JSON.parse(JSON.stringify(messageRoom));
 
-	const deleteMessageRoom = () => fetch(`/messageRooms?partner_id=${partnerId ? partnerId : ''}`, 'DELETE');
+	const deleteMessageRoom = () => fetch(`/messageRooms?partner_id=${partnerId}`, 'DELETE');
 
 	return useMutation({
 		mutationFn: deleteMessageRoom,
+
 		onSuccess: () => {
-			queryClient.removeQueries({queryKey: ['message', `${partnerId}`]});
+			if(messageRoom) {
+				messageRoom.messageRoomList.forEach((room: MessageRoom, index: number) => {
+					if(room.partner!.id !== partnerId) return;
+					copyMessageRoom.messageRoomList.splice(index, 1);
+					return false;
+				});
+				queryClient.setQueryData(['messageRoom'], copyMessageRoom);
+			}
+			queryClient.removeQueries({queryKey: ['messageRoom', `${partnerId}`]});
 			navigate(`/messages`);
+			dispatch(setToast({id: 0, type: 'success', message: '대화방에서 나갔습니다.'}));
+			return;
+		},
+
+		onError: () => {
+			dispatch(setToast({id: 0, type: 'error', message: '요청을 실패했습니다.'}));
+			return;
 		},
 	});
 };


### PR DESCRIPTION
## 개요
MessagePage.tsx에 NoSQL형식의 더미 데이터를 불러옵니다.

## 작업사항
* `/messageRoom` GET api 요청 핸들러를 NoSQL 데이터 형식에 맞춰 수정한다.
* `MessageRoomList.tsx` 컴포넌트에서 `/messageRooms` GET api 요청을 한다.
  * 요청 실패 시 `ApiErrorFallback` 컴포넌트를 보여준다.
* `/message` url 경로로 접근 시 대화방을 아무것도 클릭하지 않으면 MessageRoom은 보이지 않는다.(null상태)

## 변경로직
* `MessagePage.tsx`에 필요한 데이터를 컴포넌트 단위로 나누어 요청한다.
  * `MessageRoom.tsx` 데이터는 `/messageRoom` GET 요청으로 받는다. (특정 파트너와 대화방 데이터)
  * MessageRoomList.tsx 데이터는 `/messageRooms` GET 요청으로 받는다. (대화방 목록 데이터)
  * 대화방 나가기 클릭 시 `['message', 'list']` queryKey를 가진 데이터가 업데이트/리렌더링 된다.
    * `['message', partnerId]` queryKey를 가진 데이터는 삭제된다.

### 변경전
* /messageRoom GET api 요청으로 모든 대화방 목록, 특정 대화방 데이터를 받았습니다.

### 변경후

https://github.com/Kim-DaHam/Portfolly/assets/81691456/63ef2c75-8d55-41db-abb2-e389e18d25d1

