### PR TITLE
Feat: 포트폴리오 url 복사 기능을 만든다

### DIFF
--- a/src/components/molecules/portfolio-card/PortfolioCard.tsx
+++ b/src/components/molecules/portfolio-card/PortfolioCard.tsx
@@ -1,13 +1,15 @@
 import { HTMLAttributes, useEffect, useRef } from "react";
 import { FiMoreHorizontal as MoreIcon } from "react-icons/fi";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
+import { API_BASE_URL } from "@/app-config";
 import { Group } from "@/components/molecules/popper/Popper.styled";
 import * as S from "@/components/molecules/portfolio-card/PortfolioCard.styled";
 import { section } from "@/redux/sectionSlice";
 
 import { usePopup } from "@/hooks";
+import { setToast } from "@/redux";
 
 import { Button, ToggleButton, Popper, PortfolioSlider, Profile } from "@/components";
 
@@ -16,10 +18,25 @@ type Props = HTMLAttributes<HTMLDivElement> & {
 }
 
 export default function PortfolioCard({ portfolio, ...props }: Props) {
+	const dispatch = useDispatch();
 	const buttonGroupRef = useRef(null);
 	const currentSection = useSelector(section);
 
 	const { isPopUp, coordinate, popUp, popOut } = usePopup();
+
+	const handleCopy = () => {
+		const url = `https://${API_BASE_URL}/portfolios/${portfolio.id}`;
+		const textarea = document.createElement("textarea");
+
+		document.body.appendChild(textarea);
+		textarea.value = url;
+		textarea.select();
+		document.execCommand("copy");
+		document.body.removeChild(textarea);
+
+		popOut();
+		dispatch(setToast({id: 0, type: 'success', message: 'URL이 클립보드에 복사되었습니다.'}));
+	};
 
 	useEffect(()=>{
 		const buttonGroup :HTMLElement = buttonGroupRef.current!;
@@ -55,8 +72,8 @@ export default function PortfolioCard({ portfolio, ...props }: Props) {
 
 				<Popper coordinate={coordinate} popOut={popOut} $popperState={isPopUp}>
 					<Group>
-						<Link to=''>
-							공유하기
+						<Link to='' onClick={handleCopy}>
+							URL 복사하기
 						</Link>
 					</Group>
 				</Popper>


### PR DESCRIPTION
## 개요
`PortfolioCard.tsx` 컴포넌트의 더보기 메뉴 버튼 클릭 시 나타나는 'url 복사하기' 기능을 구현합니다.

## 작업사항
* `PortfolioCard.tsx`에 handleCopy 함수를 추가한다.
