### PR TITLE
Feat: ReactQuill에 커스텀 비디오 핸들러를 등록한다

### DIFF
--- a/src/components/molecules/editor/QuillEditor.styled.tsx
+++ b/src/components/molecules/editor/QuillEditor.styled.tsx
@@ -44,3 +44,24 @@ export const EditorContainer = styled.div`
 		height: calc(100vh - ${HEADER_HEIGHT});
   }
 `;
+
+export const Form = styled.div`
+	height: fit-content;
+
+	display: flex;
+	gap: 0.5rem;
+	padding: 0.5rem;
+`;
+
+export const Input = styled.input`
+	width: 10rem;
+	height: 2.75rem;
+
+	padding: 0 1rem;
+	font-family: 'NotoSansTTFMedium';
+	border: 1px solid #f0f0f0;
+	border-radius: 9999px;
+  background-color: white;
+	font-size: 1rem;
+	flex-basis: 1;
+`;

--- a/src/components/organisms/slider/portfolio-slider/PortfolioSlider.tsx
+++ b/src/components/organisms/slider/portfolio-slider/PortfolioSlider.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { FiArrowRight as RightArrowIcon, FiArrowLeft as LeftArrowIcon } from "react-icons/fi";
+import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import Slider from "react-slick";
 import 'slick-carousel/slick/slick.css';
@@ -67,19 +68,18 @@ export default function PortfolioSlider({section, portfolio}: Props){
 				</S.ArrowBox>
 
 				<Slider {...sliderSettings} ref={sliderRef}>
-					{portfolio.images.length > 0 &&
+					{ section !== 'Video' && portfolio.images.length > 0 &&
 						portfolio.images.map((url, index)=>{
 							if(index > 3) return;
 							return (
 								<S.SliderItem key={index}>
-									{ section !== 'Video' ?
 										<Image src={url} size='100%' alt='slider image' />
-										:
-										<S.Video src={url} />
-									}
 								</S.SliderItem>
 							);
 					})}
+					{ section === 'Video' &&
+						<S.Video src={portfolio.videos[0]} />
+					}
 				</Slider>
 			</S.Content>
 		</S.Wrapper>

--- a/src/hooks/component/usePopup.tsx
+++ b/src/hooks/component/usePopup.tsx
@@ -33,8 +33,9 @@ function usePopup() {
 		}
 	}
 
-	const popUp = (event:React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+	const popUp = (event:React.MouseEvent<HTMLButtonElement, MouseEvent> | MouseEvent) => {
 		const menuButton = event.currentTarget as HTMLElement;
+
 		setCoordinate(prev => ({
 			...prev,
 			right: getCoordinates(menuButton).right,

--- a/src/hooks/editor/useHtmlContent.ts
+++ b/src/hooks/editor/useHtmlContent.ts
@@ -20,7 +20,7 @@ export default function useHtmlContent() {
 
   const setElementInlineStyle = (htmlContent: string) => {
     let copiedHtmlContent = htmlContent;
-    copiedHtmlContent = copiedHtmlContent.replace(/<img/g, '<img style="width:100%; height:auto;"');
+    copiedHtmlContent = copiedHtmlContent.replace(/<img/g, '<img style="height:700px;"');
     copiedHtmlContent = copiedHtmlContent.replace(/<iframe/g, '<iframe style="width:100%;" height="696"');
     return copiedHtmlContent;
   }

--- a/src/hooks/editor/useImageHandler.ts
+++ b/src/hooks/editor/useImageHandler.ts
@@ -16,10 +16,9 @@ export default function useImageHandler({setValue, getValues}: Props) {
     const range = editor.getSelection();
     const url = prompt('');
 
-    if (url) {
-      editor.insertEmbed(range.index, 'image', url);
-      editor.setSelection(range.index + 1);
-    }
+    if (!url) return;
+		editor.insertEmbed(range.index, 'image', url);
+		editor.setSelection(range.index + 1);
   };
 
   const imageHandler = useCallback((editor: any) => {

--- a/src/hooks/editor/useVideoHandler.ts
+++ b/src/hooks/editor/useVideoHandler.ts
@@ -1,0 +1,23 @@
+import { useCallback, useState } from "react";
+
+type Props = {
+	popUp: (event: React.MouseEvent<HTMLButtonElement, MouseEvent> | MouseEvent) => void;
+};
+
+export default function useVideoHandler({ popUp }: Props) {
+	const [range, setRange] = useState<any>();
+
+  const videoHandler = useCallback((editor: any) => {
+		const range = editor?.getSelection();
+    const input = document.createElement('input');
+
+    input.setAttribute('type', 'button');
+		input.onclick = (event: MouseEvent) => {
+			popUp(event);
+		};
+    input.click();
+		setRange(range);
+  }, []);
+
+  return { range, videoHandler }
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -6,6 +6,7 @@ import useSearch from "@/hooks/component/useSearch";
 import useSelector from "@/hooks/component/useSelector";
 import useHtmlContent from '@/hooks/editor/useHtmlContent';
 import useImageHandler from "@/hooks/editor/useImageHandler";
+import useVideoHandler from "@/hooks/editor/useVideoHandler";
 import usePageErrorAlert from "@/hooks/error/usePageErrorAlert";
 import useIntersectionObserver from "@/hooks/event/useIntersectionObserver";
 import usePreventGoBack from "@/hooks/event/usePreventGoBack";
@@ -32,4 +33,5 @@ export {
 	usePortfolioForm,
 	useHtmlContent,
 	usePageErrorAlert,
+	useVideoHandler,
 };

--- a/src/hooks/portfolio/usePortfolioForm.ts
+++ b/src/hooks/portfolio/usePortfolioForm.ts
@@ -1,12 +1,10 @@
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
-import { useDispatch, useSelector } from "react-redux";
-
-import { toasts } from "@/redux/toastSlice";
+import { useDispatch, } from "react-redux";
 
 import type { Section } from "@/types";
 
-import { usePortfolioPostQuery, checkMultipleErrors, addValidationErrorToast } from "@/utils";
+import { usePortfolioPostQuery, addValidationErrorToast } from "@/utils";
 
 export type PortfolioFormValues = {
 	title: string;
@@ -16,6 +14,7 @@ export type PortfolioFormValues = {
 	tags: string[];
 	summary: string;
 	images: string[];
+	videos: string[];
 };
 
 const defaultValues: PortfolioFormValues = {
@@ -26,6 +25,7 @@ const defaultValues: PortfolioFormValues = {
 	tags: [],
 	summary: '',
 	images: [],
+	videos: [],
 };
 
 type Props = {
@@ -34,7 +34,6 @@ type Props = {
 
 export default function usePortfolioForm({portfolio} : Props) {
 	const dispatch = useDispatch();
-	const currentErrors = useSelector(toasts);
 
 	const portfolioMutation = usePortfolioPostQuery(portfolio ? portfolio.id : undefined);
 
@@ -69,6 +68,7 @@ export default function usePortfolioForm({portfolio} : Props) {
 
 			return portfolioMutation.mutate(changedValues);
 		}
+
 		return portfolioMutation.mutate(form);
 	};
 

--- a/src/mocks/data/portfolios.ts
+++ b/src/mocks/data/portfolios.ts
@@ -18,6 +18,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2', 'tag3'],
 		images: ['https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FbrHQt8%2FbtsEWgw3bua%2FfXBbZeGz7pTRc5OM0n5Jdk%2Fimg.png', 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FdIMWbv%2FbtsEV62jTwz%2F8NHHKxzKvr1c3ZNNqxEoo0%2Fimg.png', 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FdpXxB2%2FbtsEYMIyfhk%2FBmXO9Dc3srOihTUf8Pamxk%2Fimg.png'],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p1c1: {
@@ -105,6 +106,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: ['https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FpcGPn%2FbtsEZa3whAr%2FLMVnGlpS6Yo4VGLUkIAqY1%2Fimg.png', 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FCyC9b%2FbtsEXscLuv5%2FxBZqPDWSxDehsG6cKqMin1%2Fimg.png', 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FbGC5Jf%2FbtsE3ntU62h%2FCxPl3DUP4SgyfeuLkayBk0%2Fimg.png'],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p2c1: {
@@ -195,6 +197,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag4'],
 		images: ['https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FboIpE3%2FbtsEXqeYBQ9%2FJS8YrokTloNXJB1hOvrsI0%2Fimg.png', 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2F0Jjlv%2FbtsEWNuFAMt%2FAtLOxwISkGSh3uXkhg9Vv1%2Fimg.png', 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FbkT4eD%2FbtsE0IFbskj%2FsKtPj4DJlE3K30FTg69NAk%2Fimg.png'],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p3c1: {
@@ -285,6 +288,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: ['https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FbOQMkF%2FbtsEXsX6TZT%2FCSymXtBDmKCnegRcuvW6Z1%2Fimg.png', 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FsVubS%2FbtsE0gIV4uB%2FoUslnVCjMk5yHtqDYgKIjK%2Fimg.png', 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FbWFzAS%2FbtsEXtW0x0E%2Fn0OfUW9JbTqlGE95x6XKv0%2Fimg.png'],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p4c1: {
@@ -375,6 +379,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: ['https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2F3Cjtu%2FbtsE0hVm4Rs%2FRPeeX1Fgnvqk1v0ZPVNcK0%2Fimg.png', 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FlVP0n%2FbtsEYP6nPit%2F7vnkgAJtuUmeFlb3LGdank%2Fimg.png', 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FcNTCPW%2FbtsEZUlI4lx%2FgSidbNMuBqqd0Lr0npUpT0%2Fimg.png'],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p5c1: {
@@ -465,6 +470,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: ['https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FG5DlO%2FbtsE0HfciCs%2FEtXAgcWAnaKKnz2rn1K4HK%2Fimg.png', 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FbzvmjI%2FbtsEXqF1wQT%2FDGq03eemEUY3CltebhbkcK%2Fimg.png', 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FcFmnV7%2FbtsE2AtlDEz%2FHsLaoWPNgd7llOKx1jEbkk%2Fimg.png'],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p6c1: {
@@ -555,6 +561,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p7c1: {
@@ -645,6 +652,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p8c1: {
@@ -735,6 +743,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p9c1: {
@@ -825,6 +834,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p10c1: {
@@ -915,6 +925,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p11c1: {
@@ -1005,6 +1016,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p12c1: {
@@ -1095,6 +1107,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p13c1: {
@@ -1185,6 +1198,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p14c1: {
@@ -1275,6 +1289,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p15c1: {
@@ -1365,6 +1380,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p16c1: {
@@ -1455,6 +1471,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p17c1: {
@@ -1545,6 +1562,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p18c1: {
@@ -1635,6 +1653,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p19c1: {
@@ -1725,6 +1744,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p20c1: {
@@ -1815,6 +1835,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p21c1: {
@@ -1905,6 +1926,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p22c1: {
@@ -1995,6 +2017,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p23c1: {
@@ -2085,6 +2108,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p24c1: {
@@ -2175,6 +2199,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p25c1: {
@@ -2265,6 +2290,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p26c1: {
@@ -2355,6 +2381,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p27c1: {
@@ -2445,6 +2472,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p28c1: {
@@ -2535,6 +2563,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p29c1: {
@@ -2625,6 +2654,7 @@ export const portfolios: Portfolios = {
 		category: '금융',
 		tags: ['tag1', 'tag2'],
 		images: [],
+		videos: [],
 		likes: 5,
 		commissions: {
 			p30c1: {

--- a/src/mocks/handlers/portfolio.ts
+++ b/src/mocks/handlers/portfolio.ts
@@ -166,7 +166,7 @@ export const PortfolioHandlers= [
 		return HttpResponse.json(null, { status: 200 });
 	}),
 
-	// 포트폴리오 작성
+	// 포트폴리오 등록
 	http.post(`/portfolios`, async ({request}) => {
 		const portfolioForm = await request.json() as PortfolioFormValues;
 		const portfolioId = generateRandomString(20);

--- a/src/pages/portfolio-edit/PortfolioEditPage.constants.ts
+++ b/src/pages/portfolio-edit/PortfolioEditPage.constants.ts
@@ -10,7 +10,7 @@ export const validateContent = (getValues: UseFormGetValues<any>) => {
 		content: () => (getValues('content').length < 1) ? '포트폴리오 내용을 입력하세요.' : true,
 		images: () => {
 			if(getValues('section') === 'Video') {
-				return (getValues('images').length < 1) ? '비디오를 1개 이상 첨부하세요.' : true;
+				return (getValues('videos').length < 1) ? '비디오를 1개 이상 첨부하세요.' : true;
 			}
 
 			return (getValues('images').length < 1) ? '포트폴리오 이미지를 1개 이상 첨부하세요.' : true;

--- a/src/types/api-data/portfolio.ts
+++ b/src/types/api-data/portfolio.ts
@@ -22,6 +22,7 @@ export type Portfolio = {
 	category: string,
 	tags: string[],
 	images: string[],
+	videos: string[],
 	likes: number,
 	otherPortfolios?: Portfolio[],
 	commissions: Commissions | null,


### PR DESCRIPTION
## 개요
ReactQuill 에디터에 커스텀 비디오 핸들러를 등록합니다. 기존 비디오 핸들러는 비디오 url를 별도 저장할 수 없어서 만들었습니다.

## 작업사항
* `useVideoHandler.ts` 커스텀 훅을 생성한다.
  * 에디터 툴바의 비디오 버튼을 클릭하면 url을 입력하는 popper가 나타난다.
  * url 입력 후 'Embed'버튼 클릭 시 src 속성에 해당 url을 담은 iframe 요소가 생성된다.

## 기타
* 현재 서버의 CORS 처리를 안 해서 영상이 나타나지 않습니다.