### PR TITLE
Feat: PC, 태블릿, 모바일에 대한 media-query를 등록한다

### DIFF
--- a/src/assets/data/phrase.ts
+++ b/src/assets/data/phrase.ts
@@ -5,11 +5,3 @@ export const sectionIntroduction = {
     'Photo': 'Photo 소개문',
     'Video': 'Video 소개문',
 }
-
-export const mainPageSectionSummary = {
-	'Android/iOS': 'Android/iOS 소개문',
-	'Web': 'Web 소개문',
-	'Illustration': 'Illustration 소개문',
-	'Photo': 'Photo 소개문',
-	'Video': 'Video 소개문',
-}

--- a/src/components/molecules/portfolio-card/PortfolioCard.styled.tsx
+++ b/src/components/molecules/portfolio-card/PortfolioCard.styled.tsx
@@ -1,5 +1,10 @@
 import styled from "styled-components";
 
+import { ratios } from "@/styles/portfolio";
+import theme from "@/styles/theme";
+
+import type { Section } from "@/types";
+
 export const Wrapper = styled.div`
 	width: 100%;
 	height: 100%;
@@ -22,6 +27,14 @@ export const Wrapper = styled.div`
 			text-decoration: underline;
 		}
 	}
+
+	@media ${theme.mainPageSize.app5th} {
+		&:hover {
+			& .button-group {
+				display: none;
+			}
+		}
+	};
 `;
 
 export const ProfileBox = styled.div`

--- a/src/components/molecules/portfolio-card/PortfolioCard.tsx
+++ b/src/components/molecules/portfolio-card/PortfolioCard.tsx
@@ -11,7 +11,7 @@ import { section } from "@/redux/sectionSlice";
 import { usePopup } from "@/hooks";
 import { setToast } from "@/redux";
 
-import { Button, ToggleButton, Popper, PortfolioSlider, Profile } from "@/components";
+import { Image, Button, ToggleButton, Popper, PortfolioSlider, Profile } from "@/components";
 
 type Props = HTMLAttributes<HTMLDivElement> & {
 	portfolio: any;
@@ -50,13 +50,17 @@ export default function PortfolioCard({ portfolio, ...props }: Props) {
 
 	return (
 		<S.Wrapper {...props}>
-			<PortfolioSlider
-				section={currentSection}
-				portfolio={portfolio}
-			/>
+				<PortfolioSlider
+					section={currentSection}
+					portfolio={portfolio}
+				/>
 
 			<S.ProfileBox>
-				<Profile type='portfolio-card' portfolio={portfolio} user={portfolio.user}/>
+				<Profile
+					type='portfolio-card'
+					portfolio={portfolio}
+					user={portfolio.user}
+				/>
 
 				<S.ButtonGroup className='button-group' ref={buttonGroupRef}>
 					<ToggleButton
@@ -70,7 +74,11 @@ export default function PortfolioCard({ portfolio, ...props }: Props) {
 					</Button>
 				</S.ButtonGroup>
 
-				<Popper coordinate={coordinate} popOut={popOut} $popperState={isPopUp}>
+				<Popper
+					$popperState={isPopUp}
+					coordinate={coordinate}
+					popOut={popOut}
+				>
 					<Group>
 						<Link to='' onClick={handleCopy}>
 							URL 복사하기

--- a/src/components/molecules/searchBar/SearchBar.styled.tsx
+++ b/src/components/molecules/searchBar/SearchBar.styled.tsx
@@ -12,11 +12,21 @@ export const Wrapper = styled.div`
 
 	cursor: pointer;
 
+	overflow:hidden;
 	border-radius: 1.5rem;
 	background-color: #f0f0f0;
 
 	& span {
+		min-width: 1px;
 		font-weight: 600;
+		color: #989898;
+		overflow: hidden;
+		text-overflow:ellipsis;
+		white-space:nowrap;
+	}
+
+	& svg {
+		flex: none;
 	}
 `;
 
@@ -28,6 +38,10 @@ export const Input = styled.input`
 
 	font-weight: 600;
 	font-size: 1rem;
+
+	::placeholder, ::-webkit-input-placeholder, :-ms-input-placeholder {
+		color: #989898;
+	}
 
 	&:focus {
 		outline: none;

--- a/src/components/organisms/header/Header.styled.tsx
+++ b/src/components/organisms/header/Header.styled.tsx
@@ -1,6 +1,17 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+
+import theme from '@/styles/theme';
 
 export const HEADER_HEIGHT = '4.498rem';
+
+const wrapperMediaQuery = css`
+	@media ${theme.mainPageSize.app4th} {
+		padding: 0.3rem 1.5rem 0.3rem 1.5rem;
+	};
+	@media ${theme.mainPageSize.app5th} {
+		padding: 0.3rem 1rem 0.3rem 1rem;
+	};
+`;
 
 export const Wrapper = styled.header`
 	width: 100vw;
@@ -19,6 +30,8 @@ export const Wrapper = styled.header`
 	padding: 0.3rem 4rem 0.3rem 4rem;
 
 	background-color: white;
+
+	${wrapperMediaQuery}
 `;
 
 export const ButtonGroup = styled.nav`

--- a/src/components/organisms/modal/commission-modal/CommissionModal.tsx
+++ b/src/components/organisms/modal/commission-modal/CommissionModal.tsx
@@ -114,7 +114,7 @@ export default function CommissionModal({ commission, handleModal, editMode, $mo
 								placeholder='제목을 입력하세요'
 							/>
 							:
-							<Text size='titleSmall'>
+							<Text size='headingSmall'>
 								{commission.details?.title}
 							</Text>
 						}
@@ -214,14 +214,14 @@ export default function CommissionModal({ commission, handleModal, editMode, $mo
 							의뢰 수정
 						</Button>
 					}
-					{ authority === 'client' && commission.details?.status !== '구매 확정' &&
+					{/* { authority === 'client' && commission.details?.status !== '구매 확정' &&
 						<Button
 							color='black'
 							size='medium'
 						>
 							주문 취소
 						</Button>
-					}
+					} */}
 					{ isEditMode ?
 						<Button
 							color='black'

--- a/src/components/organisms/portfolio-list/PortfolioList.styled.ts
+++ b/src/components/organisms/portfolio-list/PortfolioList.styled.ts
@@ -1,16 +1,67 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
+
+import theme from "@/styles/theme";
+
+import type { Section } from "@/types";
+
+const getGridBoxMediaQuery = (section: Section) => {
+	if(section === 'Android/iOS') {
+		return css`
+			@media ${theme.mainPageSize.app1st} {
+				grid-template-columns: repeat(6, 1fr);
+			}
+			@media ${theme.mainPageSize.app2nd} {
+				grid-template-columns: repeat(5, 1fr);
+			}
+			@media ${theme.mainPageSize.app3rd} {
+				grid-template-columns: repeat(4, 1fr);
+			}
+			@media ${theme.mainPageSize.app4th} {
+				grid-template-columns: repeat(3, 1fr);
+			}
+			@media ${theme.mainPageSize.app6th} {
+				grid-template-columns: repeat(2, 1fr);
+			}
+			@media ${theme.mainPageSize.app7th} {
+				grid-template-columns: repeat(1, 1fr);
+			}
+		`;
+	}
+
+	return css`
+		@media ${theme.mainPageSize.web1st} {
+			grid-template-columns: repeat(4, 1fr);
+		}
+		@media ${theme.mainPageSize.web2nd} {
+			grid-template-columns: repeat(3, 1fr);
+		}
+		@media ${theme.mainPageSize.web4th} {
+			grid-template-columns: repeat(2, 1fr);
+		}
+		@media ${theme.mainPageSize.web5th} {
+			grid-template-columns: repeat(1, 1fr);
+		}
+	`;
+};
 
 export const Wrapper = styled.div`
 `;
 
-export const GridBox = styled.div`
+export const GridBox = styled.div<{section: Section}>`
 	width: 100%;
 	height: 100%;
 
 	display: grid;
-	grid-template-columns: repeat(6, 1fr);
+	grid-template-columns: ${props =>
+		props.section === 'Android/iOS' ?
+			'repeat(7, 1fr)'
+		:
+			'repeat(5, 1fr)'
+	};
 	justify-content: space-between;
 	gap: 1.7rem;
+
+	${props => getGridBoxMediaQuery(props.section)}
 `;
 
 export const Notification = styled.div`

--- a/src/components/organisms/portfolio-list/PortfolioList.tsx
+++ b/src/components/organisms/portfolio-list/PortfolioList.tsx
@@ -76,7 +76,7 @@ export default function PortfolioList({ filter }: Props) {
 
 	return (
 		<S.Wrapper>
-			<S.GridBox>
+			<S.GridBox section={currentSection}>
 				{ portfolios?.length > 0 ?
 					portfolios.map((portfolio: Portfolio, index: number)=>{
 						if(index >= showsNum) return;

--- a/src/components/organisms/slider/portfolio-slider/PortfolioSlider.styled.tsx
+++ b/src/components/organisms/slider/portfolio-slider/PortfolioSlider.styled.tsx
@@ -1,7 +1,9 @@
 import styled from 'styled-components';
 
 import { ratios } from '@/styles/portfolio';
-import { Section } from '@/types';
+import theme from '@/styles/theme';
+
+import type { Section } from '@/types';
 
 import { ButtonStyle } from '@/components';
 
@@ -32,6 +34,10 @@ export const Wrapper = styled.div<{$section: Section, $isMoreThanOnePage: boolea
 		div {
 			height: 100%;
 		}
+
+		@media ${theme.mainPageSize.app5th} {
+			border-radius: 1.5rem;
+		};
 	}
 
 	& .slick-dots {
@@ -48,6 +54,17 @@ export const Wrapper = styled.div<{$section: Section, $isMoreThanOnePage: boolea
 	& .slick-dots button {
 		pointer-events: none;
 	}
+
+	@media ${theme.mainPageSize.app5th} {
+		border-radius: 1.5rem;
+		border: 1px solid #f5f5f5;
+
+		&:hover {
+			& .slick-dots, & button {
+				opacity: 0;
+			}
+		}
+	};
 `;
 
 export const Content = styled.div`
@@ -55,6 +72,10 @@ export const Content = styled.div`
 	height: 100%;
 	position: relative;
 	padding: 1.4em 1.5em 1.4em 1.5em;
+
+	@media ${theme.mainPageSize.app5th} {
+		padding: 0;
+	};
 `;
 
 export const SliderItem = styled.div`

--- a/src/components/skeletons/portfolio-list/PortfolioListSkeleton.tsx
+++ b/src/components/skeletons/portfolio-list/PortfolioListSkeleton.tsx
@@ -1,8 +1,11 @@
+import { useSelector } from "react-redux";
 import styled from "styled-components";
 
 import { Profile } from "@/components/molecules/profile/Profile";
 import { GridBox } from "@/components/organisms/portfolio-list/PortfolioList.styled";
 import * as mixins from '@/styles/mixins';
+
+import { section } from "@/redux";
 
 import { PortfolioCardSkeleton, ProfileSkeleton } from "@/components";
 
@@ -11,8 +14,10 @@ type Props = {
 }
 
 export default function PortfolioListSkeleton({ type }: Props) {
+	const currentSection = useSelector(section);
+
 	return(
-		<GridBox>
+		<GridBox section={currentSection}>
 			{ new Array(12).fill(1).map((_, index: number)=>{
 				return(
 					<GridItem key={index}>

--- a/src/pages/log-in/LogInPage.styled.tsx
+++ b/src/pages/log-in/LogInPage.styled.tsx
@@ -3,28 +3,16 @@ import styled from "styled-components";
 import * as mixins from '@/styles/mixins';
 
 export const Wrapper = styled.main`
-	width: 100%;
-	height: 100vh;
-
-	display: flex;
-
-	padding: 0;
-`;
-
-export const LoginSection = styled.section`
-	width: 50%;
-	height: 100%;
-
+	${mixins.fullScreen}
 	${mixins.flexCenter}
 	${mixins.flexColumn}
 	gap: 2rem;
-`;
 
-export const ImageSection = styled.section`
-	width: 50%;
-	height: 100%;
+	padding: 0;
 
-	background-color: black;
+	& img {
+		cursor: pointer;
+	}
 `;
 
 export const ButtonGroup = styled.div`

--- a/src/pages/log-in/LogInPage.tsx
+++ b/src/pages/log-in/LogInPage.tsx
@@ -18,30 +18,28 @@ export default function LogIn(){
 
 	return(
 		<S.Wrapper>
-			<S.LoginSection>
-				<Image src={Logo} size='2.8rem' />
-				<Text size='title'>Welcome</Text>
+			<Image
+				src={Logo}
+				size='2.5rem'
+				onClick={() => navigate(`/main/android-ios`)}
+			/>
+			<Text size='headingMedium'>Welcome</Text>
 
-				<S.ButtonGroup>
-					<S.Box>
-						<Text size='label'>서비스를 의뢰하고 싶다면</Text>
-						<Button size='full' color='transparent' onClick={() => loginByTrial('client')}>
-							의뢰인으로 가입
-						</Button>
-					</S.Box>
+			<S.ButtonGroup>
+				<S.Box>
+					<Text size='label'>서비스를 의뢰하고 싶다면</Text>
+					<Button size='full' color='transparent' onClick={() => loginByTrial('client')}>
+						의뢰인으로 가입
+					</Button>
+				</S.Box>
 
-					<S.Box>
-						<Text size='label'>전문성을 판매하고 싶다면</Text>
-						<Button size='full' color='transparent' onClick={() => loginByTrial('expert')}>
-							전문가로 가입
-						</Button>
-					</S.Box>
-				</S.ButtonGroup>
-			</S.LoginSection>
-
-			<S.ImageSection>
-
-			</S.ImageSection>
+				<S.Box>
+					<Text size='label'>전문성을 판매하고 싶다면</Text>
+					<Button size='full' color='transparent' onClick={() => loginByTrial('expert')}>
+						전문가로 가입
+					</Button>
+				</S.Box>
+			</S.ButtonGroup>
 		</S.Wrapper>
 	)
 }

--- a/src/pages/main/MainPage.styled.tsx
+++ b/src/pages/main/MainPage.styled.tsx
@@ -1,17 +1,14 @@
 import { styled } from 'styled-components';
 
 import * as mixins from '@/styles/mixins';
+import { sizes } from '@/styles/text';
+import theme from '@/styles/theme';
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.main`
 	${mixins.fullScreen}
-	padding-top: 7rem;
-`;
-
-export const Content = styled.main`
-	width: 100%;
-
 	${mixins.flexCenter}
 	${mixins.flexColumn}
+	padding-top: 7rem;
 `;
 
 export const TitleSection = styled.section`
@@ -27,6 +24,12 @@ export const TitleSection = styled.section`
 	& span {
 		font-weight: 600;
 	}
+
+	@media ${theme.mainPageSize.app5th} {
+		& > span:first-child {
+			${sizes['headingSmall']};
+		}
+	};
 `;
 
 export const PortfolioSection = styled.section`

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -3,10 +3,8 @@ import { Suspense, lazy } from "react";
 import { ErrorBoundary as ApiErrorBoundary } from "react-error-boundary";
 import { useSelector } from "react-redux";
 
-import { mainPageSectionSummary } from '@/assets/data/phrase';
 import * as S from "@/pages/main/MainPage.styled";
 import { section } from "@/redux/sectionSlice";
-
 
 import { useDispatchSectionParameter } from "@/hooks";
 import { getFilterQueryString } from "@/utils";
@@ -25,22 +23,21 @@ export default function MainPage(){
 
 	return(
 		<S.Wrapper>
-			<S.Content>
-				<S.TitleSection>
-					<Text size='headingMedium'>{currentSection}</Text>
-					<Text size='bodyLarge'>{mainPageSectionSummary[currentSection]}</Text>
-				</S.TitleSection>
+			<S.TitleSection>
+				<Text size='headingMedium'>
+					{currentSection}
+				</Text>
+			</S.TitleSection>
 
-				<CategorySlider />
+			<CategorySlider />
 
-				<S.PortfolioSection>
-					<ApiErrorBoundary FallbackComponent={ApiErrorFallback} onReset={reset}>
-						<Suspense fallback={<PortfolioListSkeleton type='portfolio-card' />}>
-							<PortfolioCardList filter={filter} />
-						</Suspense>
-					</ApiErrorBoundary>
-				</S.PortfolioSection>
-			</S.Content>
+			<S.PortfolioSection>
+				<ApiErrorBoundary FallbackComponent={ApiErrorFallback} onReset={reset}>
+					<Suspense fallback={<PortfolioListSkeleton type='portfolio-card' />}>
+						<PortfolioCardList filter={filter} />
+					</Suspense>
+				</ApiErrorBoundary>
+			</S.PortfolioSection>
 		</S.Wrapper>
 	)
 }

--- a/src/pages/message/MessagePage.styled.tsx
+++ b/src/pages/message/MessagePage.styled.tsx
@@ -8,6 +8,7 @@ export const Wrapper = styled.div`
 `;
 
 export const Content = styled.main`
+	min-width: 1000px;
 	width: 80%;
 	height: 45rem;
 

--- a/src/pages/my-page/MyPage.styled.tsx
+++ b/src/pages/my-page/MyPage.styled.tsx
@@ -5,6 +5,8 @@ import * as mixins from '@/styles/mixins';
 export const Wrapper = styled.main`
 	${mixins.fullScreen}
 	${mixins.flexColumn}
+	min-width: 1500px;
+
 	padding: 7rem;
 
 	gap: 1.5rem;

--- a/src/pages/portfolio-detail/PortfolioDetailPage.styled.tsx
+++ b/src/pages/portfolio-detail/PortfolioDetailPage.styled.tsx
@@ -1,6 +1,7 @@
 import { styled } from 'styled-components';
 
 import * as mixins from '@/styles/mixins';
+import theme from '@/styles/theme';
 
 export const Wrapper = styled.div`
 	${mixins.fullScreen}
@@ -20,6 +21,10 @@ export const Content = styled.main`
 	gap: 2rem;
 
 	margin-top: 1rem;
+
+	@media ${theme.device.tablet} {
+		${mixins.flexColumn}
+	}
 `;
 
 export const PortfolioSection = styled.section`
@@ -43,6 +48,10 @@ export const Aside = styled.aside`
 	flex: none;
 
 	padding-bottom: 5rem;
+
+	@media ${theme.device.tablet} {
+		width: 100%;
+	}
 `;
 
 export const FlexColumnBox = styled.div`

--- a/src/pages/portfolio-detail/PortfolioDetailPage.tsx
+++ b/src/pages/portfolio-detail/PortfolioDetailPage.tsx
@@ -92,7 +92,7 @@ export default function PortfolioDetail(){
 						<Text size='bodyMedium' color='gray'>
 							{portfolio?.section} {'〉'} {portfolio?.category}
 						</Text>
-						<Text size='titleSmall'>
+						<Text size='bodyLarge'>
 							{portfolio?.title}
 						</Text>
 

--- a/src/pages/portfolio-edit/PortfolioEditPage.styled.tsx
+++ b/src/pages/portfolio-edit/PortfolioEditPage.styled.tsx
@@ -4,6 +4,7 @@ import { HEADER_HEIGHT } from '@/components/organisms/header/Header.styled';
 import * as mixins from '@/styles/mixins';
 
 export const Wrapper = styled.main`
+	min-width: 1000px;
 	width: 100%;
 	height: 100vh;
 	${mixins.flexCenter}

--- a/src/pages/search/SearchPage.styled.tsx
+++ b/src/pages/search/SearchPage.styled.tsx
@@ -1,6 +1,8 @@
 import { styled } from 'styled-components';
 
 import * as mixins from '@/styles/mixins';
+import { sizes } from '@/styles/text';
+import theme from '@/styles/theme';
 
 export const Wrapper = styled.div`
 	${mixins.fullScreen}
@@ -25,6 +27,12 @@ export const TitleSection = styled.section`
 	& button {
 		border-radius: 9999px;
 	}
+
+	@media ${theme.mainPageSize.app5th} {
+		& > span {
+			${sizes['headingSmall']};
+		}
+	};
 `;
 
 export const PortfolioSection = styled.section`

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -44,7 +44,7 @@ export default function SearchPage() {
 				</S.Box>
 
 				<Text size='headingMedium'>
-					Search "{mainFilter}"
+					"{mainFilter}"에 대한 결과
 				</Text>
 
 				<SearchFilterBar filter={filter} handleRendering={setReRendering}/>

--- a/src/styles/mixins.ts
+++ b/src/styles/mixins.ts
@@ -2,6 +2,20 @@ import { css } from 'styled-components';
 
 import { HEADER_HEIGHT } from '@/components/organisms/header/Header.styled';
 
+import theme from './theme';
+
+/** Media-Query */
+const fullScreenMediaQuery = css`
+	@media ${theme.mainPageSize.app4th} {
+		padding: 3rem 1.5rem 3rem 1.5rem;
+		padding-top: ${HEADER_HEIGHT};
+	};
+	@media ${theme.mainPageSize.app5th} {
+		padding: 3rem 1rem 3rem 1rem;
+		padding-top: ${HEADER_HEIGHT};
+	};
+`;
+
 /** Layouts */
 export const fullScreen = css`
 	width: 100vw;
@@ -10,6 +24,8 @@ export const fullScreen = css`
 
 	padding: 3rem 4rem 3rem 4rem;
 	padding-top: ${HEADER_HEIGHT};
+
+	${fullScreenMediaQuery}
 `;
 
 export const fullWidthHeight = css`

--- a/src/styles/text.ts
+++ b/src/styles/text.ts
@@ -19,9 +19,9 @@ const headingMedium = css`
 `;
 
 const headingSmall = css`
-	font-size: 1.5rem;
-	line-height: 2rem;
-	letter-spacing: -.008em;
+	font-size: 2.25rem;
+	line-height: 2.5rem;
+	letter-spacing: -.016em;
 	font-weight: 600;
 `;
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,48 @@
+const deviceSizes = {
+  mobile: "375px",
+  tablet: "768px",
+  laptop: "1024px",
+};
+
+const device = {
+  mobile: `screen and (max-width: ${deviceSizes.mobile})`,
+  tablet: `screen and (max-width: ${deviceSizes.tablet})`,
+  laptop: `screen and (max-width: ${deviceSizes.laptop})`,
+};
+
+const mainPageSizes = {
+	app1st: "2004px",
+	app2nd: "1737px",
+	app3rd: "1374px",
+	app4th: "1091px",
+	app5th: "719px",
+	app6th: "554px",
+	app7th: "373px",
+	web1st: "2175px",
+	web2nd: "1767px",
+	web3rd: "1247px",
+	web4th: "719px",
+	web5th: "635px",
+};
+
+const mainPageSize = {
+	app1st: `screen and (max-width: ${mainPageSizes.app1st})`,
+	app2nd: `screen and (max-width: ${mainPageSizes.app2nd})`,
+	app3rd: `screen and (max-width: ${mainPageSizes.app3rd})`,
+	app4th: `screen and (max-width: ${mainPageSizes.app4th})`,
+	app5th: `screen and (max-width: ${mainPageSizes.app5th})`,
+	app6th: `screen and (max-width: ${mainPageSizes.app6th})`,
+	app7th: `screen and (max-width: ${mainPageSizes.app7th})`,
+	web1st: `screen and (max-width: ${mainPageSizes.web1st})`,
+	web2nd: `screen and (max-width: ${mainPageSizes.web2nd})`,
+	web3rd: `screen and (max-width: ${mainPageSizes.web3rd})`,
+	web4th: `screen and (max-width: ${mainPageSizes.web4th})`,
+	web5th: `screen and (max-width: ${mainPageSizes.web5th})`,
+};
+
+const theme = {
+  device,
+	mainPageSize,
+};
+
+export default theme;


### PR DESCRIPTION
## 개요
PC, 태블릿, 모바일에 대한 media-query를 등록합니다.

## 작업사항
* `/styles` 하위에 미디어쿼리문 모듈 theme.ts를 생성한다.
* 반응형 UI를 제공하는 페이지 한정 미디어 쿼리 css를 등록한다.
  * 메세지, 마이페이지, 포트폴리오 작성 페이지는 반응형 UI를 제공하지 않습니다.

### 변경후

https://github.com/Kim-DaHam/Portfolly/assets/81691456/bad024e3-4b00-4bff-bdc9-6ce32c6c7a88

