### PR TITLE
Feat: 채팅방 생성 기능을 만든다

### DIFF
--- a/src/components/molecules/items/messageRoom-item/MessageRoomItem.tsx
+++ b/src/components/molecules/items/messageRoom-item/MessageRoomItem.tsx
@@ -37,7 +37,11 @@ export default function MessageRoomItem({ messageRoom }: Props) {
 						{messageRoom.partner!.nickname}
 					</Text>
 					<Text size='label' color='gray'>
-						{toLocalDateString(messageRoom.lastMessage?.createdAt || '')}
+						{ messageRoom.lastMessage ?
+							toLocalDateString(messageRoom.lastMessage?.createdAt)
+							:
+							''
+						}
 					</Text>
 				</S.LabelBox>
 

--- a/src/components/organisms/message-list/MessageList.tsx
+++ b/src/components/organisms/message-list/MessageList.tsx
@@ -20,27 +20,25 @@ export default function MessageList({ messageList={}, getValues, setValue, isFil
 
 	return (
 		<S.Wrapper id='message-box'>
-			<S.Content>
-				{ messageKeys.length > 0 ?
-					<>
-					{ messageKeys.map((docKey: string) => {
-						return (
-							<Message
-								key={docKey}
-								message={messageList[docKey]}
-								partnerProfileImage={messageList[docKey].from.profileImage}
-							/>
-						)
-					})}
-					</>
-					:
-					<S.Notification>
-						<Text size='label' color='lightgray'>
-							아직 메세지가 없어요.
-						</Text>
-					</S.Notification>
-				}
-			</S.Content>
+			{ messageKeys.length > 0 ?
+				<S.Content>
+						{ messageKeys.map((docKey: string) => {
+							return (
+								<Message
+									key={docKey}
+									message={messageList[docKey]}
+									partnerProfileImage={messageList[docKey].from.profileImage}
+								/>
+							)
+						})}
+				</S.Content>
+			:
+				<S.Notification>
+					<Text size='label' color='lightgray'>
+						아직 메세지가 없어요.
+					</Text>
+				</S.Notification>
+			}
 
 			{ isFileModalOpen &&
 				<FileModal

--- a/src/mocks/data/messages.ts
+++ b/src/mocks/data/messages.ts
@@ -1,7 +1,5 @@
 import { MessageRooms } from "@/types";
 
-import { toLocalDateString } from "@/utils";
-
 export const messageRooms: MessageRooms = {
 	room1: {
 		expert: {
@@ -244,10 +242,10 @@ export const messageRooms: MessageRooms = {
 	room2: {
 		expert: {
 			id: 'expert2',
-			name: 'John',
-			email: 'john@example.com',
+			name: 'Paul',
+			email: 'paul@example.com',
 			phone: '010-1234-1234',
-			nickname: 'John Lennon',
+			nickname: 'Paul McCartney',
 			profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 			profile: {
 				score: 90,
@@ -324,10 +322,10 @@ export const messageRooms: MessageRooms = {
 	room3: {
 		expert: {
 			id: 'expert3',
-			name: 'John',
-			email: 'john@example.com',
+			name: 'George',
+			email: 'george@example.com',
 			phone: '010-1234-1234',
-			nickname: 'John Lennon',
+			nickname: 'George Harrison',
 			profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 			profile: {
 				score: 90,
@@ -404,10 +402,10 @@ export const messageRooms: MessageRooms = {
 	room4: {
 		expert: {
 			id: 'expert4',
-			name: 'John',
-			email: 'john@example.com',
+			name: 'Ringo',
+			email: 'ringo@example.com',
 			phone: '010-1234-1234',
-			nickname: 'John Lennon',
+			nickname: 'Ringo Starr',
 			profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 			profile: {
 				score: 90,
@@ -484,10 +482,10 @@ export const messageRooms: MessageRooms = {
 	room5: {
 		expert: {
 			id: 'expert5',
-			name: 'John',
-			email: 'john@example.com',
+			name: 'Freddie',
+			email: 'freddie@example.com',
 			phone: '010-1234-1234',
-			nickname: 'John Lennon',
+			nickname: 'Freddie Mercury',
 			profileImage: 'https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FnyjLl%2FbtsCr9rPmP3%2FW1k5kiFh3yLpkK6K1fkPJK%2Fimg.webp',
 			profile: {
 				score: 90,

--- a/src/pages/message/MessagePage.tsx
+++ b/src/pages/message/MessagePage.tsx
@@ -1,20 +1,42 @@
-import { useQueryErrorResetBoundary } from "@tanstack/react-query";
+import { useQueryClient, useQueryErrorResetBoundary } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 import { ErrorBoundary as ApiErrorBoundary } from "react-error-boundary";
+import { useNavigate } from "react-router-dom";
 
 import * as S from '@/pages/message/MessagePage.styled';
+import { MessageRoom as TMessageRoom } from "@/types";
 
 import { usePageErrorAlert } from "@/hooks";
-import { useMessageRoomQuery } from "@/utils";
+import { useMessageRoomMutation, useMessageRoomQuery } from "@/utils";
 
 import { ApiErrorFallback, MessageRoom, MessageRoomList, Text } from '@/components';
 
 export default function MessagePage() {
 	const urlParams = new URL(window.location.href).searchParams;
-	const roomId = urlParams.get('room_id');
+	const roomId = urlParams.get('room_id') as string;
+	const partnerId = urlParams.get('partner_id') as string;
+	const portfolioId = urlParams.get('portfolio_id') as string;
 
+	const navigate = useNavigate();
+	const queryClient = useQueryClient();
 	const { reset } = useQueryErrorResetBoundary();
 	const { data: messageRoom, isError } = useMessageRoomQuery(roomId);
 	usePageErrorAlert(isError);
+
+	const messageRoomMutation = useMessageRoomMutation(partnerId, portfolioId);
+
+	useEffect(() => {
+		if(roomId) return;
+		const messageRoomList: TMessageRoom[] = queryClient.getQueryData(["messageRoom","list"])!;
+		const room = messageRoomList?.find((room: TMessageRoom) => room.partner!.id === partnerId);
+
+		if(!messageRoomList) return;
+		if(room) {
+			navigate(`/messages?room_id=${room.id}`);
+			return;
+		}
+		messageRoomMutation.mutate();
+	}, [messageRoom]);
 
 	return(
 		<S.Wrapper>

--- a/src/pages/portfolio-detail/PortfolioDetailPage.tsx
+++ b/src/pages/portfolio-detail/PortfolioDetailPage.tsx
@@ -79,10 +79,7 @@ export default function PortfolioDetail(){
 						<Button
 							color='black'
 							size='medium'
-							onClick={() => navigate(`/messages?
-							partner_id=${portfolio?.user.id}&
-							related_portfolio_id=${portfolio?.id}&
-							page=${1}&type=`)}
+							onClick={() => navigate(`/messages?partner_id=${portfolio?.user.id}&portfolio_id=${portfolioId}`)}
 						>
 							문의하기
 						</Button>

--- a/src/utils/api-service/message.ts
+++ b/src/utils/api-service/message.ts
@@ -26,6 +26,41 @@ export const useMessageRoomsQuery = () => {
 	});
 };
 
+// 대화방 생성하기
+export const useMessageRoomMutation = (partnerId: string, portfolioId: string) => {
+	const queryClient = useQueryClient();
+	const dispatch = useDispatch();
+	const navigate = useNavigate();
+	const messageRoomList = queryClient.getQueryData(['messageRoom', 'list']) as any[];
+	const copyMessageRoomList = messageRoomList && JSON.parse(JSON.stringify(messageRoomList));
+
+	const createMessageRoom = () => fetch(`/messageRooms?partner_id=${partnerId}&portfolio_id=${portfolioId}`, 'POST');
+
+	return useMutation({
+		mutationFn: createMessageRoom,
+
+		onSuccess: (response) => {
+			if(messageRoomList) {
+				copyMessageRoomList.push({
+					id: response.id,
+					partner: response.expert,
+					commission: response.commission,
+					lastMessage: response.lastMessage,
+				});
+				queryClient.setQueryData(['messageRoom', 'list'], copyMessageRoomList);
+			}
+			queryClient.setQueryData(['messageRoom', response.id], response);
+			navigate(`/messages?room_id=${response.id}`);
+			return;
+		},
+
+		onError: () => {
+			dispatch(setToast({id: 0, type: 'error', message: '요청을 실패했습니다.'}));
+			return;
+		},
+	});
+};
+
 // 대화방 불러오기
 export const useMessageRoomQuery = (roomId: string | null) => {
 	const getMessageRoom = () => fetch(`/messageRoom?room_id=${roomId}&page=${1}`, 'GET');


### PR DESCRIPTION
## 개요
채팅방 생성하기 기능을 추가합니다.

## 작업사항
* `useMessageRoomMutation` 커스텀 훅을 생성한다.
  * 사용자가 포트폴리오 상세보기 페이지에서 '문의하기' 버튼 클릭 시,
  * 이전에 채팅한 기록이 있는 사용자면 → 기존 채팅방 페이지로 이동한다.
  * 채팅 기록이 없는 사용자면 → `mutation`을 작동해 채팅방 생성 POST 요청한다.

### 변경후

https://github.com/Kim-DaHam/Portfolly/assets/81691456/49a72546-5eac-4321-ae11-629ba5fbee78

